### PR TITLE
feat: introduce embedding based recommender

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync
-      - run: uv run pytest tests
+      - run: uv run pytest tests -m "not slow"
       - run: uv run mypy prelims_cli
       - run: uv run ruff check
       - run: uv run ruff format --check
+
+  test-embedding:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --extra embedding
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-ruri-v3-30m-onnx
+      - run: uv run pytest tests/test_integration_embedding.py -m slow -v

--- a/prelims_cli/embedding/__init__.py
+++ b/prelims_cli/embedding/__init__.py
@@ -1,0 +1,3 @@
+from .recommender import EmbeddingRecommender
+
+__all__ = ["EmbeddingRecommender"]

--- a/prelims_cli/embedding/cache.py
+++ b/prelims_cli/embedding/cache.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sqlite3
+
+import numpy as np
+
+_CREATE_TABLE = """\
+CREATE TABLE IF NOT EXISTS embeddings (
+    file_path TEXT PRIMARY KEY,
+    content_hash TEXT NOT NULL,
+    embedding BLOB NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+class EmbeddingCache:
+    """SQLite-backed cache for article embeddings."""
+
+    def __init__(self, db_path: str) -> None:
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute(_CREATE_TABLE)
+        self.conn.commit()
+
+    def get(self, file_path: str, content_hash: str) -> np.ndarray | None:
+        """Return cached embedding if hash matches, else None."""
+        row = self.conn.execute(
+            "SELECT embedding FROM embeddings WHERE file_path = ? AND content_hash = ?",
+            (file_path, content_hash),
+        ).fetchone()
+        if row is None:
+            return None
+        return np.frombuffer(row[0], dtype=np.float32).copy()
+
+    def put(self, file_path: str, content_hash: str, embedding: np.ndarray) -> None:
+        """Insert or replace a cached embedding."""
+        self.conn.execute(
+            "INSERT OR REPLACE INTO embeddings"
+            " (file_path, content_hash, embedding)"
+            " VALUES (?, ?, ?)",
+            (file_path, content_hash, embedding.astype(np.float32).tobytes()),
+        )
+        self.conn.commit()
+
+    def put_batch(
+        self,
+        entries: list[tuple[str, str, np.ndarray]],
+    ) -> None:
+        """Batch insert embeddings in a single transaction."""
+        self.conn.executemany(
+            "INSERT OR REPLACE INTO embeddings"
+            " (file_path, content_hash, embedding)"
+            " VALUES (?, ?, ?)",
+            [(fp, ch, emb.astype(np.float32).tobytes()) for fp, ch, emb in entries],
+        )
+        self.conn.commit()
+
+    def prune(self, active_paths: set[str]) -> int:
+        """Delete rows for paths not in active_paths. Returns count deleted."""
+        cursor = self.conn.execute("SELECT file_path FROM embeddings")
+        all_paths = {row[0] for row in cursor.fetchall()}
+        stale = all_paths - active_paths
+        if stale:
+            placeholders = ",".join("?" for _ in stale)
+            self.conn.execute(
+                f"DELETE FROM embeddings WHERE file_path IN ({placeholders})",
+                list(stale),
+            )
+            self.conn.commit()
+        return len(stale)
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self.conn.close()

--- a/prelims_cli/embedding/inference.py
+++ b/prelims_cli/embedding/inference.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+LANGUAGE_MODELS = {
+    "ja": {
+        "model_name": "sirasagi62/ruri-v3-30m-ONNX",
+        "model_file": "onnx/model_quantized.onnx",
+    },
+    "en": {
+        "model_name": "onnx-community/granite-embedding-small-english-r2-ONNX",
+        "model_file": "onnx/model_quantized.onnx",
+    },
+}
+DEFAULT_LANGUAGE = "en"
+DEFAULT_MODEL_NAME = LANGUAGE_MODELS[DEFAULT_LANGUAGE]["model_name"]
+DEFAULT_MODEL_FILE = LANGUAGE_MODELS[DEFAULT_LANGUAGE]["model_file"]
+DEFAULT_TOKENIZER_FILE = "tokenizer.json"
+MAX_LENGTH = 8192
+
+
+class OnnxEmbedder:
+    """Embedding model using ONNX Runtime for CPU inference."""
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL_NAME,
+        model_file: str = DEFAULT_MODEL_FILE,
+        prefix: str = "",
+    ) -> None:
+        import onnxruntime as ort  # type: ignore[import-not-found,import-untyped]
+        from huggingface_hub import hf_hub_download  # type: ignore[import-not-found]
+        from huggingface_hub.utils import (  # type: ignore[import-not-found]
+            EntryNotFoundError,
+        )
+        from tokenizers import (  # type: ignore[import-not-found,import-untyped]
+            Tokenizer,
+        )
+
+        model_path = hf_hub_download(repo_id=model_name, filename=model_file)
+        tokenizer_path = hf_hub_download(
+            repo_id=model_name, filename=DEFAULT_TOKENIZER_FILE
+        )
+
+        # Some ONNX models store weights in a companion _data file
+        try:
+            hf_hub_download(repo_id=model_name, filename=f"{model_file}_data")
+        except EntryNotFoundError:
+            pass
+
+        self.session = ort.InferenceSession(
+            model_path, providers=["CPUExecutionProvider"]
+        )
+        self.tokenizer = Tokenizer.from_file(tokenizer_path)
+        self.tokenizer.enable_truncation(max_length=MAX_LENGTH)
+        self.prefix = prefix
+
+    def embed(self, texts: list[str]) -> np.ndarray:
+        """Compute L2-normalized embeddings for a list of texts.
+
+        Returns an (N, dim) float32 array.
+        """
+        if self.prefix:
+            texts = [self.prefix + t for t in texts]
+
+        input_ids, attention_mask = self._tokenize(texts)
+
+        outputs = self.session.run(
+            None,
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+            },
+        )
+        last_hidden_state = outputs[0]  # (N, seq_len, dim)
+
+        embeddings = _mean_pool(last_hidden_state, attention_mask)
+        embeddings = _l2_normalize(embeddings)
+        return embeddings
+
+    def _tokenize(self, texts: list[str]) -> tuple[np.ndarray, np.ndarray]:
+        """Tokenize texts and return input_ids and attention_mask arrays.
+
+        Padding is done per-batch to the longest sequence in the batch,
+        rather than globally to MAX_LENGTH, to reduce peak memory usage.
+        """
+        encodings = self.tokenizer.encode_batch(texts)
+        max_len = max(len(e.ids) for e in encodings)
+        input_ids = np.zeros((len(encodings), max_len), dtype=np.int64)
+        attention_mask = np.zeros((len(encodings), max_len), dtype=np.int64)
+        for i, e in enumerate(encodings):
+            length = len(e.ids)
+            input_ids[i, :length] = e.ids
+            attention_mask[i, :length] = e.attention_mask
+        return input_ids, attention_mask
+
+
+def _mean_pool(last_hidden_state: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+    """Mean pooling over token embeddings, respecting attention mask.
+
+    Args:
+        last_hidden_state: (N, seq_len, dim) float array
+        attention_mask: (N, seq_len) int array
+
+    Returns:
+        (N, dim) float32 array
+    """
+    mask = attention_mask[:, :, np.newaxis].astype(np.float32)
+    summed = (last_hidden_state * mask).sum(axis=1)
+    counts = mask.sum(axis=1).clip(min=1e-9)
+    return (summed / counts).astype(np.float32)
+
+
+def _l2_normalize(x: np.ndarray) -> np.ndarray:
+    """L2-normalize each row of x."""
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    norms = np.clip(norms, a_min=1e-12, a_max=None)
+    return x / norms

--- a/prelims_cli/embedding/recommender.py
+++ b/prelims_cli/embedding/recommender.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 class EmbeddingRecommender(BaseFrontMatterProcessor):
     """Generate article recommendations using ONNX embedding model similarity.
 
-    Uses ruri-v3-30m (256-dim Japanese embedding model) by default.
-    Embeddings are cached in SQLite keyed by content hash.
+    Model is selected by ``language`` (default ``"en"``).
+    Embeddings are cached in a per-language SQLite DB keyed by content hash.
 
     Parameters
     ----------
@@ -28,12 +28,18 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         Number of recommended articles (default 3).
     lower_path : bool
         Lowercase paths in recommendations (default True).
-    cache_db : str
+    cache_db : str | None
         SQLite database path for embedding cache.
-    model_name : str
+        Defaults to ``.prelims_embedding_cache_{language}.db``.
+    model_name : str | None
         HuggingFace repo ID for the ONNX model.
-    model_file : str
+        If None, resolved from ``language``.
+    model_file : str | None
         Path to the ONNX model file within the repo.
+        If None, resolved from ``language``.
+    language : str
+        Language shorthand (``"en"`` or ``"ja"``). Determines the default
+        model and cache DB name. Ignored when ``model_name`` is set explicitly.
     prefix : str
         Text prefix prepended to each article before embedding.
     batch_size : int

--- a/prelims_cli/embedding/recommender.py
+++ b/prelims_cli/embedding/recommender.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from urllib.parse import urljoin
+
+import numpy as np
+from prelims.processor.base import BaseFrontMatterProcessor  # type: ignore
+
+from .cache import EmbeddingCache
+from .inference import DEFAULT_LANGUAGE, LANGUAGE_MODELS, OnnxEmbedder
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingRecommender(BaseFrontMatterProcessor):
+    """Generate article recommendations using ONNX embedding model similarity.
+
+    Uses ruri-v3-30m (256-dim Japanese embedding model) by default.
+    Embeddings are cached in SQLite keyed by content hash.
+
+    Parameters
+    ----------
+    permalink_base : str
+        Non-file-name part of article permalinks.
+    topk : int
+        Number of recommended articles (default 3).
+    lower_path : bool
+        Lowercase paths in recommendations (default True).
+    cache_db : str
+        SQLite database path for embedding cache.
+    model_name : str
+        HuggingFace repo ID for the ONNX model.
+    model_file : str
+        Path to the ONNX model file within the repo.
+    prefix : str
+        Text prefix prepended to each article before embedding.
+    batch_size : int
+        Batch size for embedding inference.
+    max_content_chars : int
+        Truncate post content to this many characters before embedding.
+        Reduces peak memory by limiting token sequence length.
+    """
+
+    def __init__(
+        self,
+        permalink_base: str = "",
+        topk: int = 3,
+        lower_path: bool = True,
+        cache_db: str | None = None,
+        model_name: str | None = None,
+        model_file: str | None = None,
+        language: str = DEFAULT_LANGUAGE,
+        prefix: str = "",
+        batch_size: int = 8,
+        max_content_chars: int = 2000,
+    ) -> None:
+        if model_name is None:
+            if language not in LANGUAGE_MODELS:
+                raise ValueError(
+                    f"Unsupported language: {language!r}. "
+                    f"Supported: {sorted(LANGUAGE_MODELS)}"
+                )
+            model_name = LANGUAGE_MODELS[language]["model_name"]
+            model_file = LANGUAGE_MODELS[language]["model_file"]
+        elif model_file is None:
+            model_file = "onnx/model_quantized.onnx"
+
+        self.permalink_base = permalink_base
+        self.topk = topk
+        self.lower_path = lower_path
+        self.cache_db = cache_db or f".prelims_embedding_cache_{language}.db"
+        self.model_name = model_name
+        self.model_file = model_file
+        self.prefix = prefix
+        self.batch_size = batch_size
+        self.max_content_chars = max_content_chars
+
+    def process(self, posts: list, allow_overwrite: bool = True) -> None:  # type: ignore
+        """Compute embeddings and write recommendations to frontmatter."""
+        if len(posts) < 2:
+            logger.warning("Need at least 2 posts for recommendations, skipping")
+            return
+
+        cache = EmbeddingCache(self.cache_db)
+
+        try:
+            self._process_with_cache(posts, cache, allow_overwrite)
+        finally:
+            cache.close()
+
+    def _process_with_cache(
+        self,
+        posts: list,
+        cache: EmbeddingCache,
+        allow_overwrite: bool,
+    ) -> None:
+        contents = [post.content[: self.max_content_chars] for post in posts]
+        paths = [str(post.path) for post in posts]
+        hashes = [_content_hash(c) for c in contents]
+
+        # Check cache
+        embeddings: list[np.ndarray | None] = []
+        uncached_indices: list[int] = []
+        for i, (path, h) in enumerate(zip(paths, hashes)):
+            cached = cache.get(path, h)
+            if cached is not None:
+                embeddings.append(cached)
+            else:
+                embeddings.append(None)
+                uncached_indices.append(i)
+
+        n_cached = len(posts) - len(uncached_indices)
+        logger.info(f"Cache hit: {n_cached}/{len(posts)}")
+
+        # Compute missing embeddings (lazy model load)
+        if uncached_indices:
+            embedder = OnnxEmbedder(
+                model_name=self.model_name,
+                model_file=self.model_file,
+                prefix=self.prefix,
+            )
+            uncached_texts = [contents[i] for i in uncached_indices]
+
+            # Process in batches
+            new_embeddings: list[np.ndarray] = []
+            for start in range(0, len(uncached_texts), self.batch_size):
+                batch = uncached_texts[start : start + self.batch_size]
+                batch_embs = embedder.embed(batch)
+                new_embeddings.extend(batch_embs)
+
+            # Fill in and cache
+            cache_entries: list[tuple[str, str, np.ndarray]] = []
+            for idx, emb in zip(uncached_indices, new_embeddings):
+                embeddings[idx] = emb
+                cache_entries.append((paths[idx], hashes[idx], emb))
+            cache.put_batch(cache_entries)
+
+        # Build matrix and compute similarities
+        matrix = np.stack(embeddings)  # type: ignore[arg-type]
+        # Vectors are L2-normalized, so dot product = cosine similarity
+        similarities = matrix @ matrix.T
+
+        # Generate recommendations
+        for i in range(len(posts)):
+            sim_scores = similarities[i]
+            # Exclude self (similarity=1.0)
+            top_indices = np.argsort(sim_scores, kind="stable")[::-1][
+                1 : (self.topk + 1)
+            ]
+            recommend_permalinks = [
+                self._path_to_permalink(posts[j].path) for j in top_indices
+            ]
+            posts[i].update_all(
+                {"recommendations": recommend_permalinks}, allow_overwrite
+            )
+
+        # Prune deleted articles
+        active = set(paths)
+        pruned = cache.prune(active)
+        if pruned:
+            logger.info(f"Pruned {pruned} stale entries from cache")
+
+    def _path_to_permalink(self, path: Path) -> str:
+        """Convert a file path into a permalink."""
+        file = path.stem
+        if file == "index":
+            file = path.parent.name
+        if self.lower_path:
+            file = file.lower()
+        return urljoin(f"{self.permalink_base}/", f"{file}/")
+
+
+def _content_hash(content: str) -> str:
+    """SHA-256 hash of content string."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/prelims_cli/processor.py
+++ b/prelims_cli/processor.py
@@ -13,6 +13,8 @@ def set_processor(h: StaticSitePostsHandler, cfg: DictConfig) -> None:
         set_recommender(h, cfg)
     elif cfg.type == "open_graph_media_extractor":
         set_open_graph_media_extractor(h, cfg)
+    elif cfg.type == "embedding_recommender":
+        set_embedding_recommender(h, cfg)
     else:
         raise NotImplementedError(f"Unknown Processor type: {cfg.type}")
 
@@ -58,6 +60,31 @@ def set_recommender(h: StaticSitePostsHandler, cfg: DictConfig) -> None:
             **tfidf_opts,
         )
     )
+
+
+def set_embedding_recommender(h: StaticSitePostsHandler, cfg: DictConfig) -> None:
+    from .embedding import EmbeddingRecommender
+
+    with open_dict(cfg):
+        kwargs: dict[str, object] = {
+            "permalink_base": cfg.get("permalink_base", ""),
+            "topk": cfg.get("topk", 3),
+            "lower_path": cfg.get("lower_path", True),
+            "language": cfg.get("language", "en"),
+            "prefix": cfg.get("prefix", ""),
+            "batch_size": cfg.get("batch_size", 32),
+        }
+        cache_db = cfg.get("cache_db", None)
+        if cache_db is not None:
+            kwargs["cache_db"] = cache_db
+        model_name = cfg.get("model_name", None)
+        if model_name is not None:
+            kwargs["model_name"] = model_name
+        model_file = cfg.get("model_file", None)
+        if model_file is not None:
+            kwargs["model_file"] = model_file
+
+    h.register_processor(EmbeddingRecommender(**kwargs))  # type: ignore[arg-type]
 
 
 def set_open_graph_media_extractor(h: StaticSitePostsHandler, cfg: DictConfig) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
 
 [project.optional-dependencies]
 ja = ["SudachiPy>=0.6.2", "SudachiDict-full>=20211220"]
+embedding = [
+    "onnxruntime>=1.17.0",
+    "tokenizers>=0.21.0",
+    "huggingface-hub>=0.20.0",
+    "numpy>=1.24.0",
+]
 
 [project.scripts]
 prelims-cli = "prelims_cli.cli:main"
@@ -37,6 +43,9 @@ dev = [
   "mypy>=0.931",
   "ruff>=0.9",
 ]
+
+[tool.pytest.ini_options]
+markers = ["slow: marks tests that require model download (deselect with '-m \"not slow\"')"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_embedding_cache.py
+++ b/tests/test_embedding_cache.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import numpy as np
+
+from prelims_cli.embedding.cache import EmbeddingCache
+
+
+def _make_cache(tmp_path: Path) -> EmbeddingCache:
+    return EmbeddingCache(str(tmp_path / "test.db"))
+
+
+def test_put_and_get(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    emb = np.random.rand(256).astype(np.float32)
+    cache.put("a.md", "hash1", emb)
+    result = cache.get("a.md", "hash1")
+    assert result is not None
+    np.testing.assert_array_almost_equal(result, emb)
+    cache.close()
+
+
+def test_get_returns_none_on_hash_mismatch(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    emb = np.random.rand(256).astype(np.float32)
+    cache.put("a.md", "hash1", emb)
+    assert cache.get("a.md", "wrong_hash") is None
+    cache.close()
+
+
+def test_get_returns_none_for_missing_path(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    assert cache.get("nonexistent.md", "hash1") is None
+    cache.close()
+
+
+def test_put_overwrites_on_same_path(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    emb1 = np.ones(256, dtype=np.float32)
+    emb2 = np.zeros(256, dtype=np.float32)
+    cache.put("a.md", "hash1", emb1)
+    cache.put("a.md", "hash2", emb2)
+    assert cache.get("a.md", "hash1") is None
+    result = cache.get("a.md", "hash2")
+    assert result is not None
+    np.testing.assert_array_almost_equal(result, emb2)
+    cache.close()
+
+
+def test_put_batch(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    entries = [
+        ("a.md", "h1", np.ones(256, dtype=np.float32)),
+        ("b.md", "h2", np.zeros(256, dtype=np.float32)),
+    ]
+    cache.put_batch(entries)
+    r1 = cache.get("a.md", "h1")
+    r2 = cache.get("b.md", "h2")
+    assert r1 is not None
+    assert r2 is not None
+    np.testing.assert_array_almost_equal(r1, np.ones(256))
+    np.testing.assert_array_almost_equal(r2, np.zeros(256))
+    cache.close()
+
+
+def test_prune(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put("a.md", "h1", np.ones(256, dtype=np.float32))
+    cache.put("b.md", "h2", np.ones(256, dtype=np.float32))
+    cache.put("c.md", "h3", np.ones(256, dtype=np.float32))
+    deleted = cache.prune({"a.md", "c.md"})
+    assert deleted == 1
+    assert cache.get("a.md", "h1") is not None
+    assert cache.get("b.md", "h2") is None
+    assert cache.get("c.md", "h3") is not None
+    cache.close()
+
+
+def test_prune_no_stale(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.put("a.md", "h1", np.ones(256, dtype=np.float32))
+    deleted = cache.prune({"a.md"})
+    assert deleted == 0
+    cache.close()
+
+
+def test_serialization_roundtrip(tmp_path: Path) -> None:
+    """Ensure float32 fidelity through blob serialization."""
+    cache = _make_cache(tmp_path)
+    emb = np.array([1.0, -1.0, 0.5, 1e-7, 3.14], dtype=np.float32)
+    cache.put("x.md", "h", emb)
+    result = cache.get("x.md", "h")
+    assert result is not None
+    np.testing.assert_array_equal(result, emb)
+    cache.close()

--- a/tests/test_embedding_recommender.py
+++ b/tests/test_embedding_recommender.py
@@ -1,0 +1,332 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from prelims_cli.embedding.inference import LANGUAGE_MODELS
+from prelims_cli.embedding.recommender import EmbeddingRecommender, _content_hash
+
+
+def _make_post(path: str, content: str) -> MagicMock:
+    post = MagicMock()
+    post.path = Path(path)
+    post.content = content
+    return post
+
+
+def _fake_embeddings(texts: list[str]) -> np.ndarray:
+    """Generate deterministic embeddings based on text length for testing."""
+    embs = []
+    for t in texts:
+        seed = sum(ord(c) for c in t) % 1000
+        rng2 = np.random.RandomState(seed)
+        v = rng2.randn(256).astype(np.float32)
+        v /= np.linalg.norm(v)
+        embs.append(v)
+    return np.array(embs)
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_process_basic(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """Basic process: 3 posts, verify recommendations are set."""
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    posts = [
+        _make_post("/posts/a.md", "Python machine learning"),
+        _make_post("/posts/b.md", "Python deep learning"),
+        _make_post("/posts/c.md", "Cooking recipes for dinner"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=2,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec.process(posts)
+
+    for post in posts:
+        post.update_all.assert_called_once()
+        call_args = post.update_all.call_args[0]
+        assert "recommendations" in call_args[0]
+        assert len(call_args[0]["recommendations"]) == 2
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_permalink_generation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    posts = [
+        _make_post("/posts/MyPost.md", "content alpha"),
+        _make_post("/posts/other.md", "content beta"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        lower_path=True,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec.process(posts)
+
+    # Check that recommendations use lowercased permalinks
+    for post in posts:
+        recs = post.update_all.call_args[0][0]["recommendations"]
+        for r in recs:
+            assert r == r.lower()
+            assert r.startswith("/blog/")
+            assert r.endswith("/")
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_permalink_index_file(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    posts = [
+        _make_post("/posts/my-article/index.md", "content one"),
+        _make_post("/posts/other.md", "content two"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec.process(posts)
+
+    # The index.md post should recommend using parent dir name "my-article"
+    recs_for_other = posts[1].update_all.call_args[0][0]["recommendations"]
+    assert "/blog/my-article/" in recs_for_other
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_caching_behavior(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """Second run should use cache and not call embedder."""
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    posts = [
+        _make_post("/posts/a.md", "same content"),
+        _make_post("/posts/b.md", "same content two"),
+    ]
+
+    cache_path = str(tmp_path / "cache.db")
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=cache_path,
+    )
+
+    # First run: should call embedder
+    rec.process(posts)
+    assert MockEmbedder.called
+
+    # Reset mock
+    MockEmbedder.reset_mock()
+    embedder_instance.embed.reset_mock()
+
+    # Second run with same content: should NOT instantiate embedder
+    posts2 = [
+        _make_post("/posts/a.md", "same content"),
+        _make_post("/posts/b.md", "same content two"),
+    ]
+    rec2 = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=cache_path,
+    )
+    rec2.process(posts2)
+    MockEmbedder.assert_not_called()
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_partial_cache_hit(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """When some posts are cached and some aren't, only uncached are computed."""
+    call_count = 0
+
+    def tracking_embed(texts: list[str]) -> np.ndarray:
+        nonlocal call_count
+        call_count += len(texts)
+        return _fake_embeddings(texts)
+
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = tracking_embed
+
+    cache_path = str(tmp_path / "cache.db")
+
+    # First run: 2 posts
+    posts1 = [
+        _make_post("/posts/a.md", "content A"),
+        _make_post("/posts/b.md", "content B"),
+    ]
+    rec = EmbeddingRecommender(permalink_base="/blog", topk=1, cache_db=cache_path)
+    rec.process(posts1)
+    # Reset
+    call_count = 0
+    MockEmbedder.reset_mock()
+
+    # Second run: 2 cached + 1 new
+    posts2 = [
+        _make_post("/posts/a.md", "content A"),
+        _make_post("/posts/b.md", "content B"),
+        _make_post("/posts/c.md", "content C"),
+    ]
+    rec2 = EmbeddingRecommender(permalink_base="/blog", topk=1, cache_db=cache_path)
+    rec2.process(posts2)
+    # Only 1 new post should be embedded
+    assert call_count == 1
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_skip_with_single_post(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """Should skip processing with fewer than 2 posts."""
+    posts = [_make_post("/posts/a.md", "content")]
+    rec = EmbeddingRecommender(cache_db=str(tmp_path / "cache.db"))
+    rec.process(posts)
+    MockEmbedder.assert_not_called()
+    posts[0].update_all.assert_not_called()
+
+
+def test_content_hash_deterministic() -> None:
+    h1 = _content_hash("hello world")
+    h2 = _content_hash("hello world")
+    h3 = _content_hash("different")
+    assert h1 == h2
+    assert h1 != h3
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_content_truncation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """Content should be truncated to max_content_chars before embedding."""
+    embedded_texts: list[list[str]] = []
+
+    def capture_embed(texts: list[str]) -> np.ndarray:
+        embedded_texts.append(texts)
+        return _fake_embeddings(texts)
+
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = capture_embed
+
+    long_content = "A" * 5000
+    posts = [
+        _make_post("/posts/a.md", long_content),
+        _make_post("/posts/b.md", "short"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=str(tmp_path / "cache.db"),
+        max_content_chars=100,
+    )
+    rec.process(posts)
+
+    # The text passed to the embedder should be truncated
+    assert len(embedded_texts) == 1
+    batch = embedded_texts[0]
+    assert len(batch[0]) == 100
+    assert len(batch[1]) == len("short")
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_content_truncation_cache_key(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    """Cache key should reflect truncated content, not original."""
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    cache_path = str(tmp_path / "cache.db")
+
+    posts = [
+        _make_post("/posts/a.md", "A" * 5000),
+        _make_post("/posts/b.md", "short"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=cache_path,
+        max_content_chars=100,
+    )
+    rec.process(posts)
+    MockEmbedder.reset_mock()
+    embedder_instance.embed.reset_mock()
+
+    # Same original content, same truncation → cache hit
+    posts2 = [
+        _make_post("/posts/a.md", "A" * 5000),
+        _make_post("/posts/b.md", "short"),
+    ]
+    rec2 = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        cache_db=cache_path,
+        max_content_chars=100,
+    )
+    rec2.process(posts2)
+    MockEmbedder.assert_not_called()
+
+
+@patch("prelims_cli.embedding.recommender.OnnxEmbedder")
+def test_lower_path_false(MockEmbedder: MagicMock, tmp_path: Path) -> None:
+    embedder_instance = MockEmbedder.return_value
+    embedder_instance.embed.side_effect = _fake_embeddings
+
+    posts = [
+        _make_post("/posts/MyPost.md", "content alpha"),
+        _make_post("/posts/Other.md", "content beta"),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=1,
+        lower_path=False,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec.process(posts)
+
+    # Post 0 recommends Post 1 or vice versa, paths should preserve case
+    recs_0 = posts[0].update_all.call_args[0][0]["recommendations"]
+    recs_1 = posts[1].update_all.call_args[0][0]["recommendations"]
+    all_recs = recs_0 + recs_1
+    # At least one should have uppercase
+    assert any("MyPost" in r or "Other" in r for r in all_recs)
+
+
+def test_language_default_uses_english() -> None:
+    """Default (no language) should resolve to English granite model."""
+    rec = EmbeddingRecommender(permalink_base="/blog")
+    assert rec.model_name == LANGUAGE_MODELS["en"]["model_name"]
+    assert rec.model_file == LANGUAGE_MODELS["en"]["model_file"]
+    assert rec.cache_db == ".prelims_embedding_cache_en.db"
+
+
+def test_language_en_resolves_granite() -> None:
+    rec = EmbeddingRecommender(permalink_base="/blog", language="en")
+    assert rec.model_name == LANGUAGE_MODELS["en"]["model_name"]
+    assert "granite" in rec.model_name
+
+
+def test_language_ja_resolves_ruri() -> None:
+    rec = EmbeddingRecommender(permalink_base="/blog", language="ja")
+    assert rec.model_name == LANGUAGE_MODELS["ja"]["model_name"]
+    assert "ruri" in rec.model_name
+    assert rec.cache_db == ".prelims_embedding_cache_ja.db"
+
+
+def test_explicit_model_overrides_language() -> None:
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        language="ja",
+        model_name="custom/model-ONNX",
+        model_file="onnx/custom.onnx",
+    )
+    assert rec.model_name == "custom/model-ONNX"
+    assert rec.model_file == "onnx/custom.onnx"
+
+
+def test_invalid_language_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported language"):
+        EmbeddingRecommender(permalink_base="/blog", language="zz")

--- a/tests/test_integration_embedding.py
+++ b/tests/test_integration_embedding.py
@@ -1,0 +1,65 @@
+"""Integration test that uses the real ONNX model.
+
+Requires: uv sync --extra embedding
+Run with: uv run pytest tests/test_integration_embedding.py -m slow
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+slow = pytest.mark.slow
+
+ML_TEXT = "Pythonで機械学習モデルを構築する方法について解説します。"
+DL_TEXT = "Pythonでディープラーニングを実装するチュートリアルです。"
+COOK_TEXT = "今日の晩ご飯のレシピを紹介します。簡単な料理です。"
+
+
+@slow
+def test_end_to_end_with_real_model(tmp_path: Path) -> None:
+    from prelims_cli.embedding.recommender import EmbeddingRecommender
+
+    def make_post(name: str, content: str) -> MagicMock:
+        post = MagicMock()
+        post.path = Path(f"/posts/{name}.md")
+        post.content = content
+        return post
+
+    posts = [
+        make_post("python-ml", ML_TEXT),
+        make_post("python-dl", DL_TEXT),
+        make_post("cooking", COOK_TEXT),
+    ]
+
+    rec = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=2,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec.process(posts)
+
+    for post in posts:
+        post.update_all.assert_called_once()
+        recs = post.update_all.call_args[0][0]["recommendations"]
+        assert len(recs) == 2
+        assert all(r.startswith("/blog/") for r in recs)
+
+    # Python ML and DL should recommend each other as top-1
+    recs_ml = posts[0].update_all.call_args[0][0]["recommendations"]
+    recs_dl = posts[1].update_all.call_args[0][0]["recommendations"]
+    assert recs_ml[0] == "/blog/python-dl/"
+    assert recs_dl[0] == "/blog/python-ml/"
+
+    # Second run should hit cache
+    posts2 = [
+        make_post("python-ml", ML_TEXT),
+        make_post("python-dl", DL_TEXT),
+        make_post("cooking", COOK_TEXT),
+    ]
+    rec2 = EmbeddingRecommender(
+        permalink_base="/blog",
+        topk=2,
+        cache_db=str(tmp_path / "cache.db"),
+    )
+    rec2.process(posts2)

--- a/tests/test_onnx_embedder.py
+++ b/tests/test_onnx_embedder.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from prelims_cli.embedding.inference import _l2_normalize, _mean_pool
+
+
+def test_mean_pool_basic() -> None:
+    # (1, 3, 2) hidden states, all tokens active
+    hidden = np.array([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]], dtype=np.float32)
+    mask = np.array([[1, 1, 1]], dtype=np.int64)
+    result = _mean_pool(hidden, mask)
+    expected = np.array([[3.0, 4.0]], dtype=np.float32)  # mean over tokens
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_mean_pool_with_padding() -> None:
+    # 2 real tokens, 1 padding token
+    hidden = np.array([[[1.0, 2.0], [3.0, 4.0], [99.0, 99.0]]], dtype=np.float32)
+    mask = np.array([[1, 1, 0]], dtype=np.int64)
+    result = _mean_pool(hidden, mask)
+    expected = np.array([[2.0, 3.0]], dtype=np.float32)  # mean of first 2 only
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_mean_pool_batch() -> None:
+    hidden = np.array(
+        [
+            [[1.0, 0.0], [3.0, 0.0]],
+            [[0.0, 2.0], [0.0, 4.0]],
+        ],
+        dtype=np.float32,
+    )
+    mask = np.array([[1, 1], [1, 1]], dtype=np.int64)
+    result = _mean_pool(hidden, mask)
+    expected = np.array([[2.0, 0.0], [0.0, 3.0]], dtype=np.float32)
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_l2_normalize() -> None:
+    x = np.array([[3.0, 4.0], [0.0, 5.0]], dtype=np.float32)
+    result = _l2_normalize(x)
+    # Check unit norm
+    norms = np.linalg.norm(result, axis=1)
+    np.testing.assert_array_almost_equal(norms, [1.0, 1.0])
+    # Check direction preserved
+    np.testing.assert_array_almost_equal(result[0], [0.6, 0.8])
+    np.testing.assert_array_almost_equal(result[1], [0.0, 1.0])
+
+
+def test_l2_normalize_zero_vector() -> None:
+    x = np.array([[0.0, 0.0]], dtype=np.float32)
+    result = _l2_normalize(x)
+    # Should not produce NaN
+    assert not np.any(np.isnan(result))

--- a/tests/test_prelims_cli.py
+++ b/tests/test_prelims_cli.py
@@ -34,3 +34,11 @@ def test_set_processor_routes_open_graph(mock_set_og):
     cfg = OmegaConf.create({"type": "open_graph_media_extractor"})
     set_processor(handler, cfg)
     mock_set_og.assert_called_once_with(handler, cfg)
+
+
+@patch("prelims_cli.processor.set_embedding_recommender")
+def test_set_processor_routes_embedding_recommender(mock_set_emb):
+    handler = MagicMock()
+    cfg = OmegaConf.create({"type": "embedding_recommender"})
+    set_processor(handler, cfg)
+    mock_set_emb.assert_called_once_with(handler, cfg)

--- a/uv.lock
+++ b/uv.lock
@@ -7,10 +7,42 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
 
 [[package]]
 name = "click"
@@ -43,6 +75,128 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.24.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
+    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
+    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "shellingham" },
+    { name = "tqdm" },
+    { name = "typer-slim" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -146,6 +300,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -364,6 +548,45 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/4e/050c947924ffd8ff856d219d8f83ee3d4e7dc52d5a6770ff34a15675c437/onnxruntime-1.24.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:69d1c75997276106d24e65da2e69ec4302af1b117fef414e2154740cde0f6214", size = 17217298, upload-time = "2026-02-19T17:15:09.891Z" },
+    { url = "https://files.pythonhosted.org/packages/30/17/c814121dff4de962476ced979c402c3cce72d5d46e87099610b47a1f2622/onnxruntime-1.24.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:670d7e671af2dbd17638472f9b9ff98041889efd7150718406b9ea989312d064", size = 15027128, upload-time = "2026-02-19T17:13:19.367Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/32/4e5921ba8b82ac37cad45f1108ca6effd430f49c7f20577d53f317d166ed/onnxruntime-1.24.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93fe190ee555ae8e9c1214bcfcf13af85cd06dd835e8d835ce5a8d01056844fe", size = 17107440, upload-time = "2026-02-19T17:14:02.932Z" },
+    { url = "https://files.pythonhosted.org/packages/48/55/9d13c97d912db81e81c9b369a49b36f2804fa3bb8de64462e5e6bd412d0b/onnxruntime-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:04a3a80b28dd39739463cb1e34081eed668929ba0b8e1bc861885dcdf66b7601", size = 12506375, upload-time = "2026-02-19T17:14:57.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d4/cf0e0b3bd84e7b68fe911810f7098f414936d1ffb612faa569a3fb8a76a5/onnxruntime-1.24.2-cp311-cp311-win_arm64.whl", hash = "sha256:a845096277444670b0b52855bb4aad706003540bd34986b50868e9f29606c142", size = 12167758, upload-time = "2026-02-19T17:14:47.386Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1c/38af1cfe82c75d2b205eb5019834b0f2b0b6647ec8a20a3086168e413570/onnxruntime-1.24.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d8a50b422d45c0144864c0977d04ad4fa50a8a48e5153056ab1f7d06ea9fc3e2", size = 17217857, upload-time = "2026-02-19T17:15:14.297Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8a/e2d4332ae18d6383376e75141cd914256bee12c3cc439f42260eb176ceb9/onnxruntime-1.24.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76c44fc9a89dcefcd5a4ab5c6bbbb9ff1604325ab2d5d0bc9ff5a9cba7b37f4a", size = 15027167, upload-time = "2026-02-19T17:13:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/35/af/ad86cfbfd65d5a86204b3a30893e92c0cf3f1a56280efc5a12e69d81f52d/onnxruntime-1.24.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09aa6f8d766b4afc3cfba68dd10be39586b49f9462fbd1386c5d5644239461ca", size = 17106547, upload-time = "2026-02-19T17:14:05.758Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/62/9d725326f933bf8323e309956a17e52d33fb59d35bb5dda1886f94352938/onnxruntime-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:ebcee9276420a65e5fa08b05f18379c2271b5992617e5bdc0d0d6c5ea395c1a1", size = 12506161, upload-time = "2026-02-19T17:14:59.377Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a9/7b06efd5802db881860d961a7cb4efacb058ed694c1c8f096c0c1499d017/onnxruntime-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:8d770a934513f6e17937baf3438eaaec5983a23cdaedb81c9fc0dfcf26831c24", size = 12169884, upload-time = "2026-02-19T17:14:49.962Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/98/8f5b9ae63f7f6dd5fb2d192454b915ec966a421fdd0effeeef5be7f7221f/onnxruntime-1.24.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:038ebcd8363c3835ea83eed66129e1d11d8219438892dfb7dc7656c4d4dfa1f9", size = 17217884, upload-time = "2026-02-19T17:13:36.193Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e6/dc4dc59565c93506c45017c0dd3f536f6d1b7bc97047821af13fba2e3def/onnxruntime-1.24.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8235cc11e118ad749c497ba93288c04073eccd8cc6cc508c8a7988ae36ab52d8", size = 15026995, upload-time = "2026-02-19T17:13:25.029Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/62/6f2851cf3237a91bc04cdb35434293a623d4f6369f79836929600da574ba/onnxruntime-1.24.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92b46cc6d8be4286436a05382a881c88d85a2ae1ea9cfe5e6fab89f2c3e89cc", size = 17106308, upload-time = "2026-02-19T17:14:09.817Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5a/1e2b874daf24f26e98af14281fdbdd6ae1ed548ba471c01ea2a3084c55bb/onnxruntime-1.24.2-cp313-cp313-win_amd64.whl", hash = "sha256:1fd824ee4f6fb811bc47ffec2b25f129f31a087214ca91c8b4f6fda32962b78f", size = 12506095, upload-time = "2026-02-19T17:15:02.434Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/8fac5eecb94f861d56a43ede3c2ebcdce60132952d3b72003f3e3d91483c/onnxruntime-1.24.2-cp313-cp313-win_arm64.whl", hash = "sha256:d8cf0acbf90771fff012c33eb2749e8aca2a8b4c66c672f30ee77c140a6fba5b", size = 12168564, upload-time = "2026-02-19T17:14:52.28Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e4/7dfed3f445f7289a0abff709d012439c6c901915390704dd918e5f47aad3/onnxruntime-1.24.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e22fb5d9ac51b61f50cca155ce2927576cc2c42501ede6c0df23a1aeb070bdd5", size = 15036844, upload-time = "2026-02-19T17:13:27.928Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/9d52397e30b0d8c1692afcec5184ca9372ff4d6b0f6039bba9ad479a2563/onnxruntime-1.24.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2956f5220e7be8b09482ae5726caabf78eb549142cdb28523191a38e57fb6119", size = 17117779, upload-time = "2026-02-19T17:14:13.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c8/2321cd06ddbb4321326df365ccb8345cdb4e05643f539729f3943c706e97/onnxruntime-1.24.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:487e3fdedc24bc93f2acdf47c622de49b3999fb5754e7cfa466e5533a0215051", size = 17219405, upload-time = "2026-02-19T17:13:39.925Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ff/a2cdf95d2647f2a5076eb3fc49ae662e375c4eb5c7b6b675f910f96c8e15/onnxruntime-1.24.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c33398bd6ab1a6b7de9410af7360cd8b6312bc0c4848ddb738456c13dfbec4b", size = 15027713, upload-time = "2026-02-19T17:13:30.693Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/74/a1913b3a0fc2f27fe1751e9545745a3f35fd7833e3438a4208b4e215778f/onnxruntime-1.24.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2658b3ce6cb33bdeddfcd74c6da509510310717611220cf2106e6c401febabe5", size = 17106108, upload-time = "2026-02-19T17:14:16.619Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bd/fca80d282bca9848b2c8e101c764432dd61a0e9d2377d1c8b3bab13235d0/onnxruntime-1.24.2-cp314-cp314-win_amd64.whl", hash = "sha256:45b4f68ffec95b2cc0dc96b2b413f69ace9a80a0e5400023c5ac61f73a7a3fdf", size = 12808967, upload-time = "2026-02-19T17:15:05.1Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/eb/6b154dd61cac410cacf27a9f53bbf49f4dbfe5b3982f3f5b0247c7bf7b78/onnxruntime-1.24.2-cp314-cp314-win_arm64.whl", hash = "sha256:6c501aaaaa674e689aaac501e26eb96aba908ebc067fe761fbcbed868bd694a6", size = 12491892, upload-time = "2026-02-19T17:14:54.584Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/84/14e5e804836476d3ef6ac07afe3ed6bdf01b69f8ef3ce6ae82c6c80b6d62/onnxruntime-1.24.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5360d3fd9c08ce17fff757759ce4b152852be14d597130f41174d8271f954630", size = 15036834, upload-time = "2026-02-19T17:13:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/27/ecdd3ae7d49d9f54820ededce2d88ddc3333b9ac9bb5f1d0d6aa3148c686/onnxruntime-1.24.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05a2792b5ef9278a89415a1f39d0a22192a872168257100503a5157165a38e7b", size = 17117770, upload-time = "2026-02-19T17:14:20.048Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -408,7 +631,6 @@ wheels = [
 
 [[package]]
 name = "prelims-cli"
-version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -417,6 +639,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+embedding = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+]
 ja = [
     { name = "sudachidict-full" },
     { name = "sudachipy" },
@@ -432,18 +661,37 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0.3" },
+    { name = "huggingface-hub", marker = "extra == 'embedding'", specifier = ">=0.20.0" },
+    { name = "numpy", marker = "extra == 'embedding'", specifier = ">=1.24.0" },
     { name = "omegaconf", specifier = ">=2.1.1" },
+    { name = "onnxruntime", marker = "extra == 'embedding'", specifier = ">=1.17.0" },
     { name = "prelims", specifier = ">=0.0.6" },
     { name = "sudachidict-full", marker = "extra == 'ja'", specifier = ">=20211220" },
     { name = "sudachipy", marker = "extra == 'ja'", specifier = ">=0.6.2" },
+    { name = "tokenizers", marker = "extra == 'embedding'", specifier = ">=0.21.0" },
 ]
-provides-extras = ["ja"]
+provides-extras = ["embedding", "ja"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=0.931" },
     { name = "pytest", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.9" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]
@@ -535,6 +783,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]
@@ -796,6 +1057,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sudachidict-full"
 version = "20260116"
 source = { registry = "https://pypi.org/simple" }
@@ -827,12 +1097,54 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
 ]
 
 [[package]]
@@ -887,6 +1199,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typer-slim"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks to @oza I learned CPU based light weighted modern embedding models work well on GHA.

https://zenn.dev/sirasagi62/articles/a75d0ba39f0125

Here is an example config to enable them:

```yml
handlers:
  - target_path: "content/blog"
    ignore_files:
      - _index.md
    processors:
      - permalink_base: "/blog"
        type: embedding_recommender
        language: en  # Use onnx-community/granite-embedding-small-english-r2-ONNX
        topk: 3
        cache_db: ".prelims_embedding_cache_en.db"
  - target_path: "content/post"
    ignore_files:
      - _index.md
    processors:
      - permalink_base: "/post"
        type: embedding_recommender
        language: ja   # Use sirasagi62/ruri-v3-30m-ONNX
        topk: 3
        cache_db: ".prelims_embedding_cache_ja.db"
```