### PR TITLE
Keep the front matter output stable across runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,15 @@ target: /users/chezo/src/chezo.uno/content/post
 ```
 
 Then your articles' front matter were updated.
+
+Articles whose front matter did not change are left untouched, and updated ones
+are written in block style:
+
+```yaml
+tags:
+  - AI
+  - Hugo
+```
+
+This keeps the output stable across runs, so a CMS or an editor writing the same
+style does not produce a diff on every run.

--- a/prelims_cli/cli.py
+++ b/prelims_cli/cli.py
@@ -3,8 +3,8 @@ import os
 
 import click
 from omegaconf import OmegaConf, open_dict
-from prelims import StaticSitePostsHandler  # type: ignore
 
+from prelims_cli.handler import StablePostsHandler
 from prelims_cli.processor import set_processor
 
 logging.basicConfig(level=logging.INFO)
@@ -21,7 +21,7 @@ def main(config: str) -> None:
         with open_dict(handler):
             handler.ignore_files = handler.get("ignore_files", [])
             handler.encoding = handler.get("encoding", "utf-8")
-        h = StaticSitePostsHandler(
+        h = StablePostsHandler(
             handler.target_path,
             ignore_files=handler.ignore_files,
             encoding=handler.encoding,

--- a/prelims_cli/handler.py
+++ b/prelims_cli/handler.py
@@ -1,10 +1,10 @@
-import re
 from typing import Any
 
 import yaml
 from prelims import StaticSitePostsHandler  # type: ignore
 
-RE_FRONT_MATTER = re.compile(r"---\n([\s\S]*?\n)---\n")
+# Reuse the pattern prelims parsed `raw_content` with, so both see the same block
+from prelims.post import RE_FRONT_MATTER  # type: ignore
 
 
 class BlockStyleDumper(yaml.Dumper):
@@ -36,7 +36,12 @@ def save_post(post: Any) -> None:
     if post.front_matter == yaml.safe_load(m.group(1)):
         return
 
-    content = post.raw_content.replace(m.group(1), dump_front_matter(post.front_matter))
+    start, end = m.span(1)
+    content = (
+        post.raw_content[:start]
+        + dump_front_matter(post.front_matter)
+        + post.raw_content[end:]
+    )
     with open(post.path, "w", encoding=post.encoding) as f:
         f.write(content)
 

--- a/prelims_cli/handler.py
+++ b/prelims_cli/handler.py
@@ -1,0 +1,56 @@
+import re
+from typing import Any
+
+import yaml
+from prelims import StaticSitePostsHandler  # type: ignore
+
+RE_FRONT_MATTER = re.compile(r"---\n([\s\S]*?\n)---\n")
+
+
+class BlockStyleDumper(yaml.Dumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
+        # PyYAML emits `tags:\n- a`, while editors and CMSes write `tags:\n  - a`
+        return super().increase_indent(flow, False)
+
+
+def dump_front_matter(front_matter: Any) -> str:
+    return yaml.dump(
+        front_matter,
+        Dumper=BlockStyleDumper,
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=float("inf"),
+    )
+
+
+def save_post(post: Any) -> None:
+    if not post.is_valid():
+        return
+
+    m = RE_FRONT_MATTER.search(post.raw_content)
+    if m is None:
+        return
+
+    # Rewriting an untouched post only reformats it
+    if post.front_matter == yaml.safe_load(m.group(1)):
+        return
+
+    content = post.raw_content.replace(m.group(1), dump_front_matter(post.front_matter))
+    with open(post.path, "w", encoding=post.encoding) as f:
+        f.write(content)
+
+
+class StablePostsHandler(StaticSitePostsHandler):  # type: ignore
+    """Handler that keeps the front matter formatting stable across runs.
+
+    prelims re-dumps the front matter of every post it loads, so a run over
+    unchanged articles still rewrites them in a different YAML style. This
+    handler writes a post only when a processor updated its front matter, and
+    dumps it in the block style editors and CMSes produce.
+    """
+
+    @staticmethod
+    def save_posts(posts: list[Any]) -> None:
+        for post in posts:
+            save_post(post)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "prelims>=0.0.6",
   "click>=8.0.3",
   "omegaconf>=2.1.1",
+  "PyYAML>=5.1",
 ]
 
 [project.optional-dependencies]
@@ -42,6 +43,7 @@ dev = [
   "pytest>=6.0",
   "mypy>=0.931",
   "ruff>=0.9",
+  "types-PyYAML>=6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,126 @@
+from unittest.mock import MagicMock
+
+from prelims import Post  # type: ignore
+
+from prelims_cli.handler import StablePostsHandler, dump_front_matter, save_post
+
+BLOCK_STYLE = """---
+title: hello
+tags:
+  - a
+  - b
+---
+
+Hello world.
+"""
+
+FLOW_STYLE = """---
+title: hello
+tags: [a, b]
+---
+
+Hello world.
+"""
+
+DRAFT = """---
+title: hello
+draft: true
+---
+
+Hello world.
+"""
+
+
+def write_post(tmp_path, content):
+    path = tmp_path / "index.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_dump_front_matter_indents_sequences():
+    dumped = dump_front_matter({"title": "hello", "tags": ["a", "b"]})
+    assert dumped == "title: hello\ntags:\n  - a\n  - b\n"
+
+
+def test_dump_front_matter_does_not_wrap_long_values():
+    url = "https://example.com/" + "a" * 100
+    assert dump_front_matter({"url": url}) == f"url: {url}\n"
+
+
+def test_save_post_keeps_unchanged_post_untouched(tmp_path):
+    path = write_post(tmp_path, BLOCK_STYLE)
+    post = Post.load(path)
+
+    post.update("title", "bye", allow_overwrite=False)
+    save_post(post)
+
+    assert path.read_text(encoding="utf-8") == BLOCK_STYLE
+
+
+def test_save_post_keeps_unchanged_flow_style_post_untouched(tmp_path):
+    path = write_post(tmp_path, FLOW_STYLE)
+    post = Post.load(path)
+
+    save_post(post)
+
+    assert path.read_text(encoding="utf-8") == FLOW_STYLE
+
+
+def test_save_post_writes_block_style(tmp_path):
+    path = write_post(tmp_path, FLOW_STYLE)
+    post = Post.load(path)
+
+    post.update("recommendations", ["/post/x/", "/post/y/"])
+    save_post(post)
+
+    assert (
+        path.read_text(encoding="utf-8")
+        == """---
+title: hello
+tags:
+  - a
+  - b
+recommendations:
+  - /post/x/
+  - /post/y/
+---
+
+Hello world.
+"""
+    )
+
+
+def test_save_post_skips_draft(tmp_path):
+    path = write_post(tmp_path, DRAFT)
+    post = Post.load(path)
+
+    post.update("recommendations", ["/post/x/"])
+    save_post(post)
+
+    assert path.read_text(encoding="utf-8") == DRAFT
+
+
+def test_save_posts_saves_every_post(tmp_path):
+    paths = []
+    for i in range(2):
+        path = tmp_path / f"{i}.md"
+        path.write_text(FLOW_STYLE, encoding="utf-8")
+        paths.append(path)
+
+    posts = [Post.load(path) for path in paths]
+    for post in posts:
+        post.update("recommendations", ["/post/x/"])
+    StablePostsHandler.save_posts(posts)
+
+    for path in paths:
+        assert "recommendations:\n  - /post/x/\n" in path.read_text(encoding="utf-8")
+
+
+def test_save_posts_is_used_by_execute(tmp_path):
+    write_post(tmp_path, FLOW_STYLE)
+    h = StablePostsHandler(str(tmp_path))
+    h.save_posts = MagicMock()
+
+    h.execute()
+
+    h.save_posts.assert_called_once()

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -30,6 +30,15 @@ draft: true
 Hello world.
 """
 
+REPEATED_IN_BODY = """---
+title: hello
+---
+
+Hello world.
+
+title: hello
+"""
+
 
 def write_post(tmp_path, content):
     path = tmp_path / "index.md"
@@ -86,6 +95,28 @@ recommendations:
 ---
 
 Hello world.
+"""
+    )
+
+
+def test_save_post_only_replaces_the_front_matter(tmp_path):
+    path = write_post(tmp_path, REPEATED_IN_BODY)
+    post = Post.load(path)
+
+    post.update("recommendations", ["/post/x/"])
+    save_post(post)
+
+    assert (
+        path.read_text(encoding="utf-8")
+        == """---
+title: hello
+recommendations:
+  - /post/x/
+---
+
+Hello world.
+
+title: hello
 """
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -636,6 +636,7 @@ dependencies = [
     { name = "click" },
     { name = "omegaconf" },
     { name = "prelims" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -656,6 +657,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -666,6 +668,7 @@ requires-dist = [
     { name = "omegaconf", specifier = ">=2.1.1" },
     { name = "onnxruntime", marker = "extra == 'embedding'", specifier = ">=1.17.0" },
     { name = "prelims", specifier = ">=0.0.6" },
+    { name = "pyyaml", specifier = ">=5.1" },
     { name = "sudachidict-full", marker = "extra == 'ja'", specifier = ">=20211220" },
     { name = "sudachipy", marker = "extra == 'ja'", specifier = ">=0.6.2" },
     { name = "tokenizers", marker = "extra == 'embedding'", specifier = ">=0.21.0" },
@@ -677,6 +680,7 @@ dev = [
     { name = "mypy", specifier = ">=0.931" },
     { name = "pytest", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -1238,6 +1242,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

prelims re-dumps the front matter of every post it loads, so a run over unchanged articles still rewrites them. PyYAML's representation rarely matches what wrote the file, so `tags:\n  - a` from an editor comes back as `tags: [a]`.

On a CMS-backed site that turns every edit into a second commit carrying no content change, and each of those commits triggers another site build.

## Change

`StablePostsHandler` subclasses `StaticSitePostsHandler` and overrides `save_posts`. `execute()` is `load_posts` → processors → `self.save_posts`, so this stays within the public API.

- Writes a post only when a processor actually updated its front matter. The comparison parses the original out of `post.raw_content`, so it does not depend on a prelims release.
- Dumps in the block style editors and CMSes produce: `increase_indent` override so sequences are indented under their key, `default_flow_style=False`, and `width=inf` so long values are not wrapped at 80 columns.

`PyYAML` moves into `dependencies` since it is now imported directly rather than picked up transitively through prelims.

Existing articles are not reformatted in bulk: an article is only rewritten once a processor changes something in it, so the migration to block style happens lazily.

## Verification

Against a real Hugo site with 418 posts and a Sveltia CMS-shaped edit (front matter rewritten in block style):

| | result |
|---|---|
| this branch | file left untouched, block style preserved |
| released 0.0.6 | rewritten to flow style |

New tests cover the dumper output, the no-op skip for both block- and flow-style input, the block-style write, drafts, and that `execute()` routes through the override. Full suite: 41 passed, plus `ruff check`, `ruff format --check` and `mypy`.

## Note

The upstream half of this is takuti/prelims — a fix there would cover the no-op skip for all prelims users. The block style is a deliberate choice in prelims (8e4e739), so it stays here rather than going upstream as a default change.

---
_Generated by [Claude Code](https://claude.ai/code/session_013k5YY9Rhnp1PbneJptedKi)_