### PR TITLE
Bump the workflow actions off the Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync
@@ -28,12 +28,12 @@ jobs:
       matrix:
         python-version: ["3.11", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --extra embedding
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/huggingface/hub
           # Keyed on the file holding the pinned revisions: a static key would

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Why

Every job logs this:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4,
astral-sh/setup-uv@v5
```

## Changes

| action | before | after |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `astral-sh/setup-uv` | v5 | `c771a70e6277c0a99b617c7a806ffedaca235ff9` (v9.0.0) |

setup-uv is pinned to a commit, the form astral recommends. checkout and cache stay on their moving major tags.

`pypa/gh-action-pypi-publish` stays on `release/v1`, which is the reference its own documentation tells you to use.

## Compatibility

The only non-default input in play is setup-uv's `python-version`, which is still declared in v9.0.0's `action.yml`. checkout's `fetch-depth: 0` in the release workflow and cache's `path` / `key` / `restore-keys` are unchanged across these majors. CI on this PR is the check.