### PR TITLE
Add the embedding evaluation scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,7 +30,14 @@ uv run --extra embedding python scripts/compare_embedding_variants.py \
 ```
 
 It reports membership changes separately from order-only ones, and — when the
-front matter has `tags` or `categories` — how often recommendations share a tag
-with the article they are attached to, plus how concentrated recommendations
-are on a few articles. Temporary cache DBs are used, so the real ones are left
-alone.
+front matter has `tags`, `categories` or `keywords` — how often recommendations
+share a tag with the article they are attached to, plus how concentrated
+recommendations are on a few articles. Temporary cache DBs are used, so the real
+ones are left alone.
+
+Check the `tag source` lines in the output before quoting the overlap number.
+If most articles are tagged only through an auto-extracted `keywords` list, the
+metric drifts toward lexical overlap and flatters models that rank by surface
+wording. `--tag-keys tags categories` restricts it to curated tags (at the cost
+of coverage) and `--max-df 0.05` drops filler terms; running both is the way to
+tell whether a result survives.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,12 @@ prints the model's inputs and outputs, fails if it needs anything beyond
 languages and verifies that same-topic pairs come out closer than unrelated
 ones. Run it before adding a model to `LANGUAGE_MODELS`.
 
+It also reports the model's positional limit and how many characters that comes
+to in each language, which is what decides whether raising `max_content_chars`
+can do anything for that model at all. `MAX_LENGTH` truncates every model at the
+same 8192 tokens, so a model with a shorter window is fed past its limit — that
+does not raise, it just degrades, and the script warns about it.
+
 ```sh
 uv run --extra embedding python scripts/check_onnx_model.py \
     --model-name hotchpotch/bekko-embedding-v1-a8m \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,36 @@
+# scripts
+
+Evaluation helpers for the embedding recommender. Not part of the package —
+run them from a checkout with `uv run --extra embedding python scripts/<name>`.
+
+## check_onnx_model.py
+
+Checks whether an ONNX embedding model works with `OnnxEmbedder` unchanged:
+prints the model's inputs and outputs, fails if it needs anything beyond
+`input_ids` and `attention_mask`, then embeds probe sentences in several
+languages and verifies that same-topic pairs come out closer than unrelated
+ones. Run it before adding a model to `LANGUAGE_MODELS`.
+
+```sh
+uv run --extra embedding python scripts/check_onnx_model.py \
+    --model-name hotchpotch/bekko-embedding-v1-a8m \
+    --model-file onnx/model.onnx --pooling mean
+```
+
+## compare_embedding_variants.py
+
+Runs the recommender twice over the same articles with two different settings
+and reports what changed. Use it to decide whether a change to pooling, prefix
+or the model itself is an improvement, rather than eyeballing a diff.
+
+```sh
+uv run --extra embedding python scripts/compare_embedding_variants.py \
+    ../site/content/post --language ja --permalink-base /post \
+    --vary prefix --a "" --b "トピック: " --summary-only
+```
+
+It reports membership changes separately from order-only ones, and — when the
+front matter has `tags` or `categories` — how often recommendations share a tag
+with the article they are attached to, plus how concentrated recommendations
+are on a few articles. Temporary cache DBs are used, so the real ones are left
+alone.

--- a/scripts/check_onnx_model.py
+++ b/scripts/check_onnx_model.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""Check whether an ONNX embedding model works with OnnxEmbedder as-is.
+
+Answers the questions you need before adding a model to LANGUAGE_MODELS:
+does it run on input_ids + attention_mask alone, what shape does it return,
+and do its embeddings put related texts closer together than unrelated ones.
+
+    uv run --extra embedding python scripts/check_onnx_model.py \
+        --model-name hotchpotch/bekko-embedding-v1-a8m \
+        --model-file onnx/model.onnx --pooling mean
+
+Add --revision <sha> to check a specific commit. Exits non-zero if the model
+needs inputs OnnxEmbedder does not supply, which is the case that would require
+changing the embedder rather than just adding a config entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import numpy as np
+
+from prelims_cli.embedding.inference import POOLING_METHODS, OnnxEmbedder
+
+SUPPLIED_INPUTS = {"input_ids", "attention_mask"}
+
+# Two sentences on one topic and one on another, per language. If the model
+# works, the same-topic pair is the closest neighbour in every language.
+PROBES = {
+    "ja": [
+        "Pythonで機械学習モデルを構築する方法について解説します。",
+        "Pythonでディープラーニングを実装するチュートリアルです。",
+        "今日の晩ご飯のレシピを紹介します。簡単な料理です。",
+    ],
+    "en": [
+        "How to build a machine learning model in Python, step by step.",
+        "A tutorial on implementing deep learning models with Python.",
+        "Tonight's dinner recipe: a simple dish anyone can cook.",
+    ],
+    "fr": [
+        "Comment construire un modèle d'apprentissage automatique en Python.",
+        "Un tutoriel sur l'implémentation du deep learning avec Python.",
+        "La recette du dîner de ce soir : un plat simple à cuisiner.",
+    ],
+}
+
+
+def describe_io(embedder: OnnxEmbedder) -> set[str]:
+    """Print the model's inputs and outputs; return required input names."""
+    print("inputs:")
+    required = set()
+    for i in embedder.session.get_inputs():
+        print(f"  {i.name:<20} {i.type:<24} {i.shape}")
+        required.add(i.name)
+    print("outputs:")
+    for o in embedder.session.get_outputs():
+        print(f"  {o.name:<20} {o.type:<24} {o.shape}")
+    return required
+
+
+def report_probes(embedder: OnnxEmbedder) -> bool:
+    """Embed each probe set; return True if every same-topic pair wins."""
+    all_passed = True
+    for language, texts in PROBES.items():
+        embeddings = embedder.embed(texts)
+        similarities = embeddings @ embeddings.T
+        related = similarities[0, 1]
+        unrelated = max(similarities[0, 2], similarities[1, 2])
+        passed = related > unrelated
+        all_passed &= passed
+        print(
+            f"  {language}: related={related:+.3f} unrelated={unrelated:+.3f} "
+            f"{'ok' if passed else 'FAILED — unrelated text is closer'}"
+        )
+    return all_passed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--model-file", default="onnx/model.onnx")
+    parser.add_argument("--pooling", required=True, choices=list(POOLING_METHODS))
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--prefix", default="")
+    args = parser.parse_args()
+
+    print(f"{args.model_name} @ {args.revision or 'default branch'}")
+    print(f"file={args.model_file} pooling={args.pooling} prefix={args.prefix!r}\n")
+
+    embedder = OnnxEmbedder(
+        model_name=args.model_name,
+        model_file=args.model_file,
+        pooling=args.pooling,
+        revision=args.revision,
+        prefix=args.prefix,
+    )
+
+    required = describe_io(embedder)
+    extra = required - SUPPLIED_INPUTS
+    print()
+    if extra:
+        print(f"NOT USABLE AS-IS: model also requires {sorted(extra)}.")
+        print("OnnxEmbedder only feeds input_ids and attention_mask.")
+        return 1
+    print("inputs are covered by OnnxEmbedder (input_ids + attention_mask)")
+
+    embeddings = embedder.embed(PROBES["en"])
+    norms = np.linalg.norm(embeddings, axis=1)
+    print(f"embedding shape: {embeddings.shape} (dim={embeddings.shape[1]})")
+    print(f"L2 norms: {norms.round(4).tolist()}")
+
+    print("\nsame-topic pair should beat the unrelated one:")
+    if not report_probes(embedder):
+        print("\nmodel runs but the embeddings do not separate topics.")
+        print("Check the pooling method against the model card before using it.")
+        return 1
+
+    print("\nusable: add it to LANGUAGE_MODELS with the settings above.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_onnx_model.py
+++ b/scripts/check_onnx_model.py
@@ -81,6 +81,10 @@ def report_pooling_match(embedder: OnnxEmbedder, texts: list[str]) -> str | None
     module, so whichever of ours reproduces it is the one the model wants —
     which beats reading the model card.
     """
+    # embed() prepends the prefix before tokenizing; matching that here keeps
+    # the comparison on the same inputs the real embeddings are built from.
+    if embedder.prefix:
+        texts = [embedder.prefix + t for t in texts]
     input_ids, attention_mask = embedder._tokenize(texts)
     outputs = embedder.session.run(
         None, {"input_ids": input_ids, "attention_mask": attention_mask}

--- a/scripts/check_onnx_model.py
+++ b/scripts/check_onnx_model.py
@@ -17,11 +17,14 @@ changing the embedder rather than just adding a config entry.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+from pathlib import Path
 
 import numpy as np
 
 from prelims_cli.embedding.inference import (
+    MAX_LENGTH,
     POOLING_METHODS,
     OnnxEmbedder,
     _cls_pool,
@@ -104,6 +107,54 @@ def report_pooling_match(embedder: OnnxEmbedder, texts: list[str]) -> str | None
     return best
 
 
+def report_context_window(
+    embedder: OnnxEmbedder, model_name: str, revision: str | None
+) -> None:
+    """Report how much of an article this model can actually see.
+
+    `max_content_chars` is a character budget, but models are limited in
+    tokens, and the rate differs by language — the same 8,000 characters is
+    several times more tokens in Japanese than in English. A model whose
+    positional limit is below what we feed it cannot benefit from a longer
+    budget no matter what the comparison numbers say, so check this before
+    spending a run on it.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import EntryNotFoundError
+
+    limit = None
+    try:
+        config_path = hf_hub_download(
+            repo_id=model_name, filename="config.json", revision=revision
+        )
+        config = json.loads(Path(config_path).read_text())
+        limit = config.get("max_position_embeddings")
+        print(f"  architecture: {config.get('model_type', 'unknown')}")
+        print(f"  max_position_embeddings: {limit if limit else 'not declared'}")
+    except (EntryNotFoundError, OSError, ValueError) as exc:
+        print(f"  config.json unavailable ({type(exc).__name__}) — limit unknown")
+
+    print(f"  we truncate at: {MAX_LENGTH} tokens (MAX_LENGTH, same for every model)")
+    if limit and MAX_LENGTH > limit:
+        print(
+            f"  WARNING: MAX_LENGTH exceeds this model's {limit}-token limit. Long"
+            " articles are fed past it, which does not raise — it just degrades."
+        )
+
+    # Characters per token, so a max_content_chars budget can be read in tokens.
+    # Estimated from short probe sentences, so treat it as a rough rate.
+    print("  characters per token (rough, from probe text):")
+    for language, texts in PROBES.items():
+        text = "".join(texts)
+        tokens = len(embedder.tokenizer.encode(text).ids)
+        rate = len(text) / tokens
+        budget = int(limit * rate) if limit else None
+        line = f"    {language}: {rate:.1f} chars/token"
+        if budget:
+            line += f" — its {limit}-token limit is about {budget:,} characters"
+        print(line)
+
+
 def report_probes(embedder: OnnxEmbedder) -> bool:
     """Embed each probe set; return True if every same-topic pair wins."""
     all_passed = True
@@ -165,6 +216,9 @@ def main() -> int:
     norms = np.linalg.norm(embeddings, axis=1)
     print(f"embedding shape: {embeddings.shape} (dim={embeddings.shape[1]})")
     print(f"L2 norms: {norms.round(4).tolist()}")
+
+    print("\nhow much of an article can it see?")
+    report_context_window(embedder, args.model_name, args.revision)
 
     print("\nwhich pooling does the model itself use?")
     wanted = report_pooling_match(embedder, PROBES["en"])

--- a/scripts/check_onnx_model.py
+++ b/scripts/check_onnx_model.py
@@ -21,7 +21,13 @@ import sys
 
 import numpy as np
 
-from prelims_cli.embedding.inference import POOLING_METHODS, OnnxEmbedder
+from prelims_cli.embedding.inference import (
+    POOLING_METHODS,
+    OnnxEmbedder,
+    _cls_pool,
+    _l2_normalize,
+    _mean_pool,
+)
 
 SUPPLIED_INPUTS = {"input_ids", "attention_mask"}
 
@@ -62,6 +68,40 @@ def describe_io(embedder: OnnxEmbedder) -> tuple[set[str], list]:
     for o in outputs:
         print(f"  {o.name:<20} {o.type:<24} {o.shape}")
     return required, list(outputs[0].shape)
+
+
+def report_pooling_match(embedder: OnnxEmbedder, texts: list[str]) -> str | None:
+    """Compare both pooling methods against the model's own pooled output.
+
+    Sentence-transformers exports often ship a `sentence_embedding` output
+    alongside the token states. It was produced by the model's own pooling
+    module, so whichever of ours reproduces it is the one the model wants —
+    which beats reading the model card.
+    """
+    input_ids, attention_mask = embedder._tokenize(texts)
+    outputs = embedder.session.run(
+        None, {"input_ids": input_ids, "attention_mask": attention_mask}
+    )
+    pooled = next((o for o in outputs[1:] if o.ndim == 2), None)
+    if pooled is None:
+        print("no pooled output exported — pooling cannot be verified here")
+        return None
+
+    reference = _l2_normalize(pooled)
+    candidates = {
+        "mean": _mean_pool(outputs[0], attention_mask),
+        "cls": _cls_pool(outputs[0]),
+    }
+    best, best_sim = None, -1.0
+    for name, vectors in candidates.items():
+        sim = float((_l2_normalize(vectors) * reference).sum(axis=1).mean())
+        print(f"  {name:<6} vs exported sentence_embedding: cosine {sim:+.4f}")
+        if sim > best_sim:
+            best, best_sim = name, sim
+    if best_sim < 0.99:
+        print("  neither reproduces it closely — the export may pool differently")
+        return None
+    return best
 
 
 def report_probes(embedder: OnnxEmbedder) -> bool:
@@ -125,6 +165,17 @@ def main() -> int:
     norms = np.linalg.norm(embeddings, axis=1)
     print(f"embedding shape: {embeddings.shape} (dim={embeddings.shape[1]})")
     print(f"L2 norms: {norms.round(4).tolist()}")
+
+    print("\nwhich pooling does the model itself use?")
+    wanted = report_pooling_match(embedder, PROBES["en"])
+    if wanted and wanted != args.pooling:
+        print(
+            f"\nWRONG POOLING: this export pools with {wanted!r}, not {args.pooling!r}."
+        )
+        print("Re-run with the right one; the difference does not raise on its own.")
+        return 1
+    if wanted:
+        print(f"  confirmed: {wanted}")
 
     print("\nsame-topic pair should beat the unrelated one:")
     if not report_probes(embedder):

--- a/scripts/check_onnx_model.py
+++ b/scripts/check_onnx_model.py
@@ -46,17 +46,22 @@ PROBES = {
 }
 
 
-def describe_io(embedder: OnnxEmbedder) -> set[str]:
-    """Print the model's inputs and outputs; return required input names."""
+def describe_io(embedder: OnnxEmbedder) -> tuple[set[str], list]:
+    """Print the model's inputs and outputs.
+
+    Returns the required input names and the shape of the first output, which
+    is what embed() pools over.
+    """
     print("inputs:")
     required = set()
     for i in embedder.session.get_inputs():
         print(f"  {i.name:<20} {i.type:<24} {i.shape}")
         required.add(i.name)
     print("outputs:")
-    for o in embedder.session.get_outputs():
+    outputs = embedder.session.get_outputs()
+    for o in outputs:
         print(f"  {o.name:<20} {o.type:<24} {o.shape}")
-    return required
+    return required, list(outputs[0].shape)
 
 
 def report_probes(embedder: OnnxEmbedder) -> bool:
@@ -96,7 +101,7 @@ def main() -> int:
         prefix=args.prefix,
     )
 
-    required = describe_io(embedder)
+    required, first_output_shape = describe_io(embedder)
     extra = required - SUPPLIED_INPUTS
     print()
     if extra:
@@ -104,6 +109,17 @@ def main() -> int:
         print("OnnxEmbedder only feeds input_ids and attention_mask.")
         return 1
     print("inputs are covered by OnnxEmbedder (input_ids + attention_mask)")
+
+    # embed() pools over outputs[0] and expects (batch, seq_len, dim). An
+    # export whose first output is already pooled would make _cls_pool return
+    # a garbage 1-D slice instead of failing.
+    if len(first_output_shape) != 3:
+        print(
+            f"NOT USABLE AS-IS: first output has rank {len(first_output_shape)}"
+            f" {first_output_shape}, expected (batch, seq_len, dim)."
+        )
+        print("It looks pre-pooled; embed() would pool it a second time.")
+        return 1
 
     embeddings = embedder.embed(PROBES["en"])
     norms = np.linalg.norm(embeddings, axis=1)

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -22,11 +22,17 @@ Your real cache DBs are never touched.
         --b "model_name=hotchpotch/bekko-embedding-v1-a8m,\
 model_file=onnx/model.onnx,pooling=mean"
 
-Metrics, when the front matter carries tags/categories:
+Metrics, when the front matter carries tags/categories/keywords:
 
   tag overlap  fraction of recommendations sharing >=1 tag with the article
                they are recommended for, and the mean number of shared tags.
                Higher is better — a proxy for "topically related".
+               Read the "tag source" lines before trusting it: an
+               auto-extracted `keywords` list turns this into something close
+               to lexical overlap, which flatters models that rank by surface
+               wording. Re-run with --tag-keys tags categories to check a
+               result against curated tags only, and --max-df to drop filler
+               terms that match everywhere.
   hub spread   how concentrated recommendations are on a few articles. A
                generic post that attaches to everything shows up as a high
                max in-degree and a high top-5 share. Lower is better.
@@ -42,6 +48,7 @@ from __future__ import annotations
 import argparse
 import tempfile
 from collections import Counter
+from collections.abc import Sequence
 from pathlib import Path
 
 import yaml
@@ -80,15 +87,35 @@ def split_front_matter(path: Path) -> tuple[dict, str]:
     return (meta if isinstance(meta, dict) else {}), body
 
 
-def tags_of(meta: dict) -> set[str]:
+def tags_of(meta: dict, keys: Sequence[str] = TAG_KEYS) -> set[str]:
     tags: set[str] = set()
-    for key in TAG_KEYS:
+    for key in keys:
         value = meta.get(key)
         if isinstance(value, str):
             tags.add(value.strip().lower())
         elif isinstance(value, list):
             tags.update(str(v).strip().lower() for v in value if v is not None)
     return tags
+
+
+def drop_common(
+    tagged: dict[Path, set[str]], max_df: float
+) -> tuple[dict[Path, set[str]], list[tuple[str, int]]]:
+    """Drop terms that appear in more than max_df of the tagged articles.
+
+    Auto-extracted keyword lists carry filler terms that match everywhere and
+    say nothing about topic. Returns the filtered map and what was dropped.
+    """
+    if max_df >= 1.0:
+        return tagged, []
+    df = Counter(term for terms in tagged.values() for term in terms)
+    limit = max_df * len(tagged)
+    dropped = sorted(
+        ((t, n) for t, n in df.items() if n > limit), key=lambda kv: -kv[1]
+    )
+    stop = {t for t, _ in dropped}
+    filtered = {p: terms - stop for p, terms in tagged.items()}
+    return {p: terms for p, terms in filtered.items() if terms}, dropped
 
 
 def parse_config(spec: str) -> dict[str, str]:
@@ -183,6 +210,21 @@ def main() -> None:
     parser.add_argument("--b", default="cls", help="candidate value (after)")
     parser.add_argument("--ignore", nargs="*", default=["_index.md"])
     parser.add_argument(
+        "--tag-keys",
+        nargs="+",
+        default=list(TAG_KEYS),
+        help="front matter keys used as tags. Auto-extracted `keywords` make "
+        "the metric closer to lexical overlap, which favours models that rank "
+        "by surface wording — restrict to curated keys to check a result",
+    )
+    parser.add_argument(
+        "--max-df",
+        type=float,
+        default=1.0,
+        help="drop tags appearing in more than this fraction of articles "
+        "(1.0 = keep everything). Filters filler terms out of keyword lists",
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=0,
@@ -217,7 +259,12 @@ def main() -> None:
     mapper = EmbeddingRecommender(
         permalink_base=args.permalink_base, language=args.language
     )
-    tagged = {p: tags_of(meta) for p, (meta, _) in parsed.items() if tags_of(meta)}
+    tagged = {
+        p: tags_of(meta, args.tag_keys)
+        for p, (meta, _) in parsed.items()
+        if tags_of(meta, args.tag_keys)
+    }
+    tagged, dropped = drop_common(tagged, args.max_df)
     tags_by_permalink = {str(p): tags for p, tags in tagged.items()}
     tags_by_permalink.update(
         {mapper._path_to_permalink(p): tags for p, tags in tagged.items()}
@@ -255,8 +302,18 @@ def main() -> None:
     )
 
     if not tagged:
-        print("\nno tags/categories in front matter — skipping tag overlap")
+        print(f"\nnone of {args.tag_keys} found in front matter — skipping tag overlap")
     else:
+        # Which key actually carries the tags decides what the metric means, so
+        # report it rather than letting one key quietly stand in for the others.
+        print(f"\ntag source ({len(tagged)}/{len(paths)} articles tagged)")
+        for key in args.tag_keys:
+            n = sum(1 for _, (meta, _) in parsed.items() if meta.get(key))
+            print(f"  {key:<12}{n:>5} articles")
+        if dropped:
+            shown = ", ".join(f"{t} ({n})" for t, n in dropped[:5])
+            print(f"  dropped over --max-df {args.max_df}: {len(dropped)} — {shown}")
+
         print(f"\ntag overlap (higher is better), topk={args.topk}")
         print(f"{'variant':<24}{'any-tag':>10}{'avg shared':>13}{'scored':>9}")
         for value, recs in ((args.a, before), (args.b, after)):

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -46,6 +46,7 @@ Requires: uv sync --extra embedding
 from __future__ import annotations
 
 import argparse
+import difflib
 import hashlib
 import inspect
 import tempfile
@@ -125,12 +126,16 @@ def cache_db_for(home: str, args: argparse.Namespace, spec: str) -> str:
     """Path of the cache DB for one variant.
 
     Named after what the variant is rather than whether it is --a or --b, so a
-    persistent --cache-dir survives swapping the two, and a corpus never shares
-    a file with another one (prune() would delete the other corpus's rows).
-    Embeddings do not depend on topk, so a sweep reuses them all.
+    persistent --cache-dir survives swapping the two. Embeddings do not depend
+    on topk, so a sweep reuses them all.
+
+    The corpus's full path is in the digest, not just its directory name: two
+    checkouts can both end in content/blog, and sharing a file between them
+    would let prune() delete the other corpus's rows.
     """
-    digest = hashlib.sha1(f"{args.vary}\0{spec}".encode()).hexdigest()[:8]
-    return str(Path(home) / f"{args.content_dir.name}-{digest}.db")
+    corpus = args.content_dir.resolve()
+    digest = hashlib.sha1(f"{corpus}\0{args.vary}\0{spec}".encode()).hexdigest()[:8]
+    return str(Path(home) / f"{corpus.name}-{digest}.db")
 
 
 def parse_config(spec: str) -> dict[str, object]:
@@ -147,11 +152,29 @@ def parse_config(spec: str) -> dict[str, object]:
         if "=" not in pair:
             raise ValueError(f"expected key=value, got {pair.strip()!r}")
         key, value = pair.split("=", 1)
-        kwargs[key.strip()] = _coerce(key.strip(), value)
+        key = key.strip()
+        if key in RESERVED_KEYS:
+            raise ValueError(
+                f"{key!r} is set by this script and cannot be varied; "
+                f"use --{key.replace('_', '-')} instead"
+            )
+        if key not in _PARAMS:
+            close = difflib.get_close_matches(key, sorted(set(_PARAMS) - {"self"}))
+            hint = f" Did you mean {close[0]!r}?" if close else ""
+            raise ValueError(
+                f"unknown setting {key!r}."
+                f" Known: {sorted(set(_PARAMS) - RESERVED_KEYS - {'self'})}.{hint}"
+            )
+        kwargs[key] = _coerce(key, value)
     return kwargs
 
 
 _PARAMS = inspect.signature(EmbeddingRecommender.__init__).parameters
+
+# Varying these would make the report describe something other than what ran:
+# topk is printed from args and drives the metrics, and permalink_base and
+# lower_path decide the keys that recommendations are matched on.
+RESERVED_KEYS = frozenset({"permalink_base", "topk", "lower_path", "cache_db"})
 
 
 def _coerce(key: str, value: str) -> object:

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import inspect
 import tempfile
 from collections import Counter
 from collections.abc import Sequence
@@ -132,22 +133,39 @@ def cache_db_for(home: str, args: argparse.Namespace, spec: str) -> str:
     return str(Path(home) / f"{args.content_dir.name}-{digest}.db")
 
 
-def parse_config(spec: str) -> dict[str, str]:
+def parse_config(spec: str) -> dict[str, object]:
     """Parse "model_name=x,pooling=mean" into kwargs.
 
     Values are taken verbatim: ruri-v3's prefix is "トピック: " with a trailing
     space, and stripping it silently embeds something else than the model was
     trained for.
     """
-    kwargs = {}
+    kwargs: dict[str, object] = {}
     for pair in spec.split(","):
         if not pair.strip():
             continue
         if "=" not in pair:
             raise ValueError(f"expected key=value, got {pair.strip()!r}")
         key, value = pair.split("=", 1)
-        kwargs[key.strip()] = value
+        kwargs[key.strip()] = _coerce(key.strip(), value)
     return kwargs
+
+
+_PARAMS = inspect.signature(EmbeddingRecommender.__init__).parameters
+
+
+def _coerce(key: str, value: str) -> object:
+    """Cast to the type of the recommender's default for that parameter.
+
+    max_content_chars and batch_size are ints; handing them a string makes the
+    slice raise deep inside process().
+    """
+    default = _PARAMS[key].default if key in _PARAMS else None
+    if isinstance(default, bool):
+        return value.strip().lower() not in ("false", "0", "no")
+    if isinstance(default, int):
+        return int(value)
+    return value
 
 
 def run_variant(

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -238,6 +238,16 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Without this the spec is passed through as a pooling method and the error
+    # comes from deep inside the recommender, naming neither flag.
+    if args.vary != "config":
+        for flag, value in (("--a", args.a), ("--b", args.b)):
+            if "=" in value:
+                parser.error(
+                    f"{flag} is {value!r}, which looks like a config spec, but "
+                    f"--vary is {args.vary!r}. Add --vary config."
+                )
+
     paths = sorted(
         p
         for p in args.content_dir.rglob("*.md")

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -157,8 +157,12 @@ def run_variant(
 
 def tag_overlap(
     recs: dict[str, list[str]], tags_by_permalink: dict[str, set[str]]
-) -> tuple[float, float, int]:
-    """Return (fraction sharing >=1 tag, mean shared tags, articles scored)."""
+) -> tuple[float, float, int, int]:
+    """Return (fraction sharing >=1 tag, mean shared tags, articles, pairs).
+
+    Only pairs where both articles carry tags are counted, so a corpus that is
+    mostly untagged resolves far less than its article count suggests.
+    """
     hits = shared = considered = scored = 0
     for path, recommended in recs.items():
         own = tags_by_permalink.get(path)
@@ -174,8 +178,8 @@ def tag_overlap(
             shared += overlap
             hits += overlap > 0
     if not considered:
-        return 0.0, 0.0, scored
-    return hits / considered, shared / considered, scored
+        return 0.0, 0.0, scored, 0
+    return hits / considered, shared / considered, scored, considered
 
 
 def hub_spread(recs: dict[str, list[str]]) -> tuple[int, float]:
@@ -325,10 +329,16 @@ def main() -> None:
             print(f"  dropped over --max-df {args.max_df}: {len(dropped)} — {shown}")
 
         print(f"\ntag overlap (higher is better), topk={args.topk}")
-        print(f"{'variant':<24}{'any-tag':>10}{'avg shared':>13}{'scored':>9}")
+        header = f"{'variant':<24}{'any-tag':>10}{'avg shared':>13}"
+        print(f"{header}{'scored':>9}{'pairs':>8}")
         for value, recs in ((args.a, before), (args.b, after)):
-            frac, mean, scored = tag_overlap(recs, tags_by_permalink)
-            print(f"{label_of(value):<24}{frac:>10.3f}{mean:>13.3f}{scored:>9}")
+            frac, mean, scored, pairs = tag_overlap(recs, tags_by_permalink)
+            row = f"{label_of(value):<24}{frac:>10.3f}{mean:>13.3f}"
+            print(f"{row}{scored:>9}{pairs:>8}")
+        print(
+            "  pairs = recommendations where both articles are tagged; "
+            "a difference smaller than a few pairs is noise"
+        )
 
     print("\nhub spread (lower is better)")
     print(f"{'variant':<24}{'max in-deg':>12}{'top-5 share':>14}")

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -133,16 +133,20 @@ def cache_db_for(home: str, args: argparse.Namespace, spec: str) -> str:
 
 
 def parse_config(spec: str) -> dict[str, str]:
-    """Parse "model_name=x,pooling=mean" into kwargs."""
+    """Parse "model_name=x,pooling=mean" into kwargs.
+
+    Values are taken verbatim: ruri-v3's prefix is "トピック: " with a trailing
+    space, and stripping it silently embeds something else than the model was
+    trained for.
+    """
     kwargs = {}
     for pair in spec.split(","):
-        pair = pair.strip()
-        if not pair:
+        if not pair.strip():
             continue
         if "=" not in pair:
-            raise ValueError(f"expected key=value, got {pair!r}")
+            raise ValueError(f"expected key=value, got {pair.strip()!r}")
         key, value = pair.split("=", 1)
-        kwargs[key.strip()] = value.strip()
+        kwargs[key.strip()] = value
     return kwargs
 
 

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -46,9 +46,11 @@ Requires: uv sync --extra embedding
 from __future__ import annotations
 
 import argparse
+import hashlib
 import tempfile
 from collections import Counter
 from collections.abc import Sequence
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
 import yaml
@@ -116,6 +118,18 @@ def drop_common(
     stop = {t for t, _ in dropped}
     filtered = {p: terms - stop for p, terms in tagged.items()}
     return {p: terms for p, terms in filtered.items() if terms}, dropped
+
+
+def cache_db_for(home: str, args: argparse.Namespace, spec: str) -> str:
+    """Path of the cache DB for one variant.
+
+    Named after what the variant is rather than whether it is --a or --b, so a
+    persistent --cache-dir survives swapping the two, and a corpus never shares
+    a file with another one (prune() would delete the other corpus's rows).
+    Embeddings do not depend on topk, so a sweep reuses them all.
+    """
+    digest = hashlib.sha1(f"{args.vary}\0{spec}".encode()).hexdigest()[:8]
+    return str(Path(home) / f"{args.content_dir.name}-{digest}.db")
 
 
 def parse_config(spec: str) -> dict[str, str]:
@@ -214,6 +228,14 @@ def main() -> None:
     parser.add_argument("--b", default="cls", help="candidate value (after)")
     parser.add_argument("--ignore", nargs="*", default=["_index.md"])
     parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="keep the embedding caches here instead of throwaway DBs, so "
+        "re-running — with a different --topk, say — costs no embedding. "
+        "Each variant gets its own file keyed by its settings",
+    )
+    parser.add_argument(
         "--tag-keys",
         nargs="+",
         default=list(TAG_KEYS),
@@ -263,10 +285,20 @@ def main() -> None:
     parsed = {p: split_front_matter(p) for p in paths}
     bodies = {p: body for p, (_, body) in parsed.items()}
 
-    with tempfile.TemporaryDirectory() as tmp:
+    if args.cache_dir:
+        args.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_home: AbstractContextManager[str] = nullcontext(str(args.cache_dir))
+    else:
+        cache_home = tempfile.TemporaryDirectory()
+
+    with cache_home as home:
         print(f"{len(paths)} articles, varying {args.vary}: {args.a!r} -> {args.b!r}\n")
-        before = run_variant(paths, bodies, args, args.a, f"{tmp}/a.db")
-        after = run_variant(paths, bodies, args, args.b, f"{tmp}/b.db")
+        before = run_variant(
+            paths, bodies, args, args.a, cache_db_for(home, args, args.a)
+        )
+        after = run_variant(
+            paths, bodies, args, args.b, cache_db_for(home, args, args.b)
+        )
 
     # The recommender maps file paths to permalinks; to look up a recommended
     # article's tags we need the reverse, so recompute them the same way.

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+"""Diff and score the related-article output of two embedding settings.
+
+Runs the recommender twice over the same articles — once per variant — into
+throwaway cache DBs, then reports what changed and which variant looks better.
+Your real cache DBs are never touched.
+
+    # pooling
+    uv run --extra embedding python scripts/compare_embedding_variants.py \
+        content/blog --language en --permalink-base /blog \
+        --vary pooling --a mean --b cls
+
+    # prefix
+    uv run --extra embedding python scripts/compare_embedding_variants.py \
+        content/post --language ja --permalink-base /post \
+        --vary prefix --a "" --b "トピック: " --summary-only
+
+    # a different model entirely (key=value pairs passed to EmbeddingRecommender)
+    uv run --extra embedding python scripts/compare_embedding_variants.py \
+        content/post --language ja --permalink-base /post --topk 5 --vary config \
+        --a "language=ja" \
+        --b "model_name=hotchpotch/bekko-embedding-v1-a8m,\
+model_file=onnx/model.onnx,pooling=mean"
+
+Metrics, when the front matter carries tags/categories:
+
+  tag overlap  fraction of recommendations sharing >=1 tag with the article
+               they are recommended for, and the mean number of shared tags.
+               Higher is better — a proxy for "topically related".
+  hub spread   how concentrated recommendations are on a few articles. A
+               generic post that attaches to everything shows up as a high
+               max in-degree and a high top-5 share. Lower is better.
+
+Changes are split into membership changes (different articles recommended) and
+order-only changes (same set, reshuffled), because the latter barely matter.
+
+Requires: uv sync --extra embedding
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+from prelims_cli.embedding.recommender import EmbeddingRecommender
+
+TAG_KEYS = ("tags", "categories", "keywords")
+
+
+class Post:
+    """Minimal stand-in for a prelims post."""
+
+    def __init__(self, path: Path, content: str) -> None:
+        self.path = path
+        self.content = content
+        self.recommendations: list[str] = []
+
+    def update_all(self, values: dict, allow_overwrite: bool = True) -> None:
+        self.recommendations = values["recommendations"]
+
+
+def split_front_matter(path: Path) -> tuple[dict, str]:
+    """Return (front matter dict, body). Best-effort on odd files."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}, text
+    _, _, rest = text.partition("\n")
+    end = rest.find("\n---")
+    if end == -1:
+        return {}, text
+    head, body = rest[:end], rest[end + len("\n---") :].lstrip()
+    try:
+        meta = yaml.safe_load(head)
+    except yaml.YAMLError:
+        return {}, body
+    return (meta if isinstance(meta, dict) else {}), body
+
+
+def tags_of(meta: dict) -> set[str]:
+    tags: set[str] = set()
+    for key in TAG_KEYS:
+        value = meta.get(key)
+        if isinstance(value, str):
+            tags.add(value.strip().lower())
+        elif isinstance(value, list):
+            tags.update(str(v).strip().lower() for v in value if v is not None)
+    return tags
+
+
+def parse_config(spec: str) -> dict[str, str]:
+    """Parse "model_name=x,pooling=mean" into kwargs."""
+    kwargs = {}
+    for pair in spec.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise ValueError(f"expected key=value, got {pair!r}")
+        key, value = pair.split("=", 1)
+        kwargs[key.strip()] = value.strip()
+    return kwargs
+
+
+def run_variant(
+    paths: list[Path],
+    bodies: dict[Path, str],
+    args: argparse.Namespace,
+    value: str,
+    cache_db: str,
+) -> dict[str, list[str]]:
+    kwargs: dict[str, object] = {
+        "permalink_base": args.permalink_base,
+        "topk": args.topk,
+        "language": args.language,
+        "cache_db": cache_db,
+    }
+    if args.vary == "config":
+        kwargs.update(parse_config(value))
+    else:
+        kwargs[args.vary] = value
+
+    posts = [Post(p, bodies[p]) for p in paths]
+    EmbeddingRecommender(**kwargs).process(posts)  # type: ignore[arg-type]
+    return {str(p.path): p.recommendations for p in posts}
+
+
+def tag_overlap(
+    recs: dict[str, list[str]], tags_by_permalink: dict[str, set[str]]
+) -> tuple[float, float, int]:
+    """Return (fraction sharing >=1 tag, mean shared tags, articles scored)."""
+    hits = shared = considered = scored = 0
+    for path, recommended in recs.items():
+        own = tags_by_permalink.get(path)
+        if not own:
+            continue
+        scored += 1
+        for permalink in recommended:
+            other = tags_by_permalink.get(permalink)
+            if other is None:
+                continue
+            considered += 1
+            overlap = len(own & other)
+            shared += overlap
+            hits += overlap > 0
+    if not considered:
+        return 0.0, 0.0, scored
+    return hits / considered, shared / considered, scored
+
+
+def hub_spread(recs: dict[str, list[str]]) -> tuple[int, float]:
+    """Return (max in-degree, share of all slots taken by the top 5 articles)."""
+    counts = Counter(p for recommended in recs.values() for p in recommended)
+    total = sum(counts.values())
+    if not total:
+        return 0, 0.0
+    top5 = sum(c for _, c in counts.most_common(5))
+    return counts.most_common(1)[0][1], top5 / total
+
+
+def label_of(value: str, width: int = 22) -> str:
+    """Short table label. Full values are printed in the header line."""
+    label = repr(value) if value != "" else "'' (empty)"
+    return label if len(label) <= width else label[: width - 3] + "..."
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("content_dir", type=Path)
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--permalink-base", default="")
+    parser.add_argument("--topk", type=int, default=3)
+    parser.add_argument(
+        "--vary",
+        choices=["pooling", "prefix", "config"],
+        default="pooling",
+        help="config: --a/--b are key=value pairs for EmbeddingRecommender",
+    )
+    parser.add_argument("--a", default="mean", help="baseline value (before)")
+    parser.add_argument("--b", default="cls", help="candidate value (after)")
+    parser.add_argument("--ignore", nargs="*", default=["_index.md"])
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="print at most N per-article diffs (0 = all); the count of "
+        "omitted ones is reported",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="skip the per-article diff, print only the summary and metrics",
+    )
+    args = parser.parse_args()
+
+    paths = sorted(
+        p
+        for p in args.content_dir.rglob("*.md")
+        if p.name not in args.ignore and not p.name.startswith(".")
+    )
+    if len(paths) < 2:
+        parser.error(f"need at least 2 articles under {args.content_dir}")
+
+    parsed = {p: split_front_matter(p) for p in paths}
+    bodies = {p: body for p, (_, body) in parsed.items()}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        print(f"{len(paths)} articles, varying {args.vary}: {args.a!r} -> {args.b!r}\n")
+        before = run_variant(paths, bodies, args, args.a, f"{tmp}/a.db")
+        after = run_variant(paths, bodies, args, args.b, f"{tmp}/b.db")
+
+    # The recommender maps file paths to permalinks; to look up a recommended
+    # article's tags we need the reverse, so recompute them the same way.
+    mapper = EmbeddingRecommender(
+        permalink_base=args.permalink_base, language=args.language
+    )
+    tagged = {p: tags_of(meta) for p, (meta, _) in parsed.items() if tags_of(meta)}
+    tags_by_permalink = {str(p): tags for p, tags in tagged.items()}
+    tags_by_permalink.update(
+        {mapper._path_to_permalink(p): tags for p, tags in tagged.items()}
+    )
+
+    membership = order_only = printed = omitted = 0
+    for path in before:
+        if before[path] == after[path]:
+            continue
+        same_set = set(before[path]) == set(after[path])
+        if same_set:
+            order_only += 1
+        else:
+            membership += 1
+        if args.summary_only:
+            continue
+        if args.limit and printed >= args.limit:
+            omitted += 1
+            continue
+        printed += 1
+        print(f"{path}{'  (order only)' if same_set else ''}")
+        for r in before[path]:
+            print(f"  - {r}")
+        for r in after[path]:
+            print(f"  + {r}")
+        print()
+
+    if omitted:
+        print(f"({omitted} more changed articles not shown, --limit {args.limit})\n")
+
+    changed = membership + order_only
+    print(
+        f"{changed}/{len(before)} articles changed: "
+        f"{membership} membership, {order_only} order only"
+    )
+
+    if not tagged:
+        print("\nno tags/categories in front matter — skipping tag overlap")
+    else:
+        print(f"\ntag overlap (higher is better), topk={args.topk}")
+        print(f"{'variant':<24}{'any-tag':>10}{'avg shared':>13}{'scored':>9}")
+        for value, recs in ((args.a, before), (args.b, after)):
+            frac, mean, scored = tag_overlap(recs, tags_by_permalink)
+            print(f"{label_of(value):<24}{frac:>10.3f}{mean:>13.3f}{scored:>9}")
+
+    print("\nhub spread (lower is better)")
+    print(f"{'variant':<24}{'max in-deg':>12}{'top-5 share':>14}")
+    for value, recs in ((args.a, before), (args.b, after)):
+        peak, share = hub_spread(recs)
+        print(f"{label_of(value):<24}{peak:>12}{share:>13.1%}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Both scripts came out of the pooling investigation and were living outside the repo. Keeping them here means the next model or setting question starts from a tool instead of from scratch. Neither is part of the package.

## `scripts/check_onnx_model.py`

Answers whether a model can be added to `LANGUAGE_MODELS` as a config entry, or whether it would need `OnnxEmbedder` changed. Prints the ONNX inputs and outputs, exits non-zero when the model requires anything beyond `input_ids` and `attention_mask`, then embeds probe sentences in ja/en/fr and checks that the same-topic pair beats the unrelated one — which catches a wrong pooling method, since that does not raise on its own.

```sh
uv run --extra embedding python scripts/check_onnx_model.py \
    --model-name hotchpotch/bekko-embedding-v1-a8m \
    --model-file onnx/model.onnx --pooling mean
```

## `scripts/compare_embedding_variants.py`

Runs the recommender twice over one corpus into throwaway cache DBs and reports what changed, so a change can be judged on evidence rather than by reading a diff of a few hundred articles.

- membership changes counted separately from order-only reshuffles
- tag overlap: how often a recommendation shares a tag with the article it is attached to
- hub spread: max in-degree and top-5 share, which is what catches a generic article attaching to everything

`--vary pooling` and `--vary prefix` cover the settings; `--vary config` takes arbitrary `key=value` pairs for `EmbeddingRecommender`, so two different models can be compared on the same articles.

These are the numbers the pooling change was accepted on: tag overlap 0.657 → 0.707, max in-degree 11 → 8, top-5 share 38.4% → 33.3%.

## Tests

No unit tests — these are operator tools whose output is judged by a human. Both were exercised against stub embedders covering the usable path, the "model needs extra inputs" path, `--vary config`, and `--limit`. ruff clean; the existing suite is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd)_