### PR TITLE
Batch embeddings by token budget, and embed 8000 characters by default

### DIFF
--- a/prelims_cli/embedding/inference.py
+++ b/prelims_cli/embedding/inference.py
@@ -46,6 +46,20 @@ DEFAULT_MODEL_FILE = LANGUAGE_MODELS[DEFAULT_LANGUAGE]["model_file"]
 DEFAULT_TOKENIZER_FILE = "tokenizer.json"
 MAX_LENGTH = 8192
 
+# Batches are padded to their longest member and attention memory grows with
+# the square of that length, so a fixed number of texts per batch makes peak
+# memory depend on which texts happen to land together. Article lengths are
+# heavily skewed — on a 419-post corpus truncated at 8000 chars the median is
+# 545 tokens and the longest is 3636 — so with a fixed batch of 8 in file
+# order, nearly every batch caught a long post and got padded up to it: twice
+# the token slots and three times the attention work actually needed.
+#
+# Batching to a budget of padded token slots instead bounds that. Sorting by
+# length first is what makes the budget effective: neighbours have similar
+# lengths, so little padding is wasted, and long texts end up in small batches
+# while short ones pack into large ones. The order is restored afterwards.
+TOKEN_BUDGET = 4096
+
 
 class OnnxEmbedder:
     """Embedding model using ONNX Runtime for CPU inference."""
@@ -58,6 +72,8 @@ class OnnxEmbedder:
         pooling: str,
         revision: str | None = None,
         prefix: str = "",
+        batch_size: int = 8,
+        token_budget: int = TOKEN_BUDGET,
     ) -> None:
         if pooling not in POOLING_METHODS:
             raise ValueError(
@@ -96,9 +112,33 @@ class OnnxEmbedder:
         self.pooling = pooling
         self.revision = revision
         self.prefix = prefix
+        self.batch_size = batch_size
+        self.token_budget = token_budget
+
+    def embed_all(self, texts: list[str]) -> np.ndarray:
+        """Embed texts in memory-bounded batches, in input order.
+
+        Prefer this over calling embed() in a loop: it groups texts of similar
+        length together so batches are not padded up to an unrelated long one,
+        and caps each batch by padded token slots rather than by count.
+
+        Returns an (N, dim) float32 array.
+        """
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+
+        lengths = self._token_lengths(texts)
+        embeddings: list[np.ndarray | None] = [None] * len(texts)
+        for batch in _plan_batches(lengths, self.token_budget, self.batch_size):
+            for i, embedding in zip(batch, self.embed([texts[i] for i in batch])):
+                embeddings[i] = embedding
+        return np.stack(embeddings)  # type: ignore[arg-type]
 
     def embed(self, texts: list[str]) -> np.ndarray:
-        """Compute L2-normalized embeddings for a list of texts.
+        """Compute L2-normalized embeddings for a list of texts as one batch.
+
+        Every text is padded to the longest one here, so pass a batch that
+        embed_all() planned rather than an arbitrary list.
 
         Returns an (N, dim) float32 array.
         """
@@ -123,6 +163,16 @@ class OnnxEmbedder:
         embeddings = _l2_normalize(embeddings)
         return embeddings
 
+    def _token_lengths(self, texts: list[str]) -> list[int]:
+        """Token count per text, as embed() would see it.
+
+        The prefix is included because it is prepended before tokenizing, and
+        truncation is already enabled, so these are capped at MAX_LENGTH.
+        """
+        if self.prefix:
+            texts = [self.prefix + t for t in texts]
+        return [len(e.ids) for e in self.tokenizer.encode_batch(texts)]
+
     def _tokenize(self, texts: list[str]) -> tuple[np.ndarray, np.ndarray]:
         """Tokenize texts and return input_ids and attention_mask arrays.
 
@@ -138,6 +188,46 @@ class OnnxEmbedder:
             input_ids[i, :length] = e.ids
             attention_mask[i, :length] = e.attention_mask
         return input_ids, attention_mask
+
+
+def _plan_batches(
+    lengths: list[int], token_budget: int, max_batch: int
+) -> list[list[int]]:
+    """Group indices into batches of similar length under a token budget.
+
+    A batch costs ``len(batch) * max(lengths in batch)`` token slots once
+    padded; batches are grown until adding the next text would exceed
+    ``token_budget`` slots or ``max_batch`` texts. Sorting by length first
+    keeps that padding close to the real token count.
+
+    A text longer than the budget on its own gets a batch to itself rather
+    than being dropped or split — truncation to MAX_LENGTH is the only thing
+    that bounds it.
+
+    Args:
+        lengths: token count per text, indexed as the caller's list
+        token_budget: maximum padded token slots per batch
+        max_batch: maximum texts per batch
+
+    Returns:
+        Lists of indices into ``lengths``, together covering every index once.
+    """
+    batches: list[list[int]] = []
+    current: list[int] = []
+    current_max = 0
+    for i in sorted(range(len(lengths)), key=lambda i: lengths[i]):
+        padded_max = max(current_max, lengths[i])
+        if current and (
+            len(current) + 1 > max_batch
+            or (len(current) + 1) * padded_max > token_budget
+        ):
+            batches.append(current)
+            current, padded_max = [], lengths[i]
+        current.append(i)
+        current_max = padded_max
+    if current:
+        batches.append(current)
+    return batches
 
 
 def _mean_pool(last_hidden_state: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:

--- a/prelims_cli/embedding/inference.py
+++ b/prelims_cli/embedding/inference.py
@@ -79,6 +79,13 @@ class OnnxEmbedder:
             raise ValueError(
                 f"Unsupported pooling: {pooling!r}. Supported: {list(POOLING_METHODS)}"
             )
+        # Both are site-configurable. Zero or negative values do not fail on
+        # their own — they quietly degrade to one text per batch — so reject
+        # them here, where the setting came from.
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be at least 1, got {batch_size}")
+        if token_budget < 1:
+            raise ValueError(f"token_budget must be at least 1, got {token_budget}")
 
         import onnxruntime as ort  # type: ignore[import-not-found,import-untyped]
         from huggingface_hub import hf_hub_download  # type: ignore[import-not-found]
@@ -130,9 +137,19 @@ class OnnxEmbedder:
         lengths = self._token_lengths(texts)
         embeddings: list[np.ndarray | None] = [None] * len(texts)
         for batch in _plan_batches(lengths, self.token_budget, self.batch_size):
-            for i, embedding in zip(batch, self.embed([texts[i] for i in batch])):
+            # strict=True so a batch that comes back the wrong size fails here,
+            # naming the cause, rather than later as a stack of Nones.
+            rows = self.embed([texts[i] for i in batch])
+            for i, embedding in zip(batch, rows, strict=True):
                 embeddings[i] = embedding
-        return np.stack(embeddings)  # type: ignore[arg-type]
+
+        filled = [e for e in embeddings if e is not None]
+        if len(filled) != len(texts):
+            raise RuntimeError(
+                f"batching covered {len(filled)} of {len(texts)} texts; "
+                "every text must land in exactly one batch"
+            )
+        return np.stack(filled)
 
     def embed(self, texts: list[str]) -> np.ndarray:
         """Compute L2-normalized embeddings for a list of texts as one batch.

--- a/prelims_cli/embedding/recommender.py
+++ b/prelims_cli/embedding/recommender.py
@@ -14,6 +14,7 @@ from .inference import (
     EMBEDDING_CACHE_VERSION,
     LANGUAGE_MODELS,
     POOLING_METHODS,
+    TOKEN_BUDGET,
     OnnxEmbedder,
 )
 
@@ -58,7 +59,12 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
     prefix : str
         Text prefix prepended to each article before embedding.
     batch_size : int
-        Batch size for embedding inference.
+        Maximum posts per inference batch. A batch may hold fewer when the
+        posts are long, since ``token_budget`` also applies.
+    token_budget : int
+        Maximum padded token slots per inference batch. This is what bounds
+        peak memory; ``batch_size`` alone cannot, because memory depends on
+        the length of the posts in the batch, not their number.
     max_content_chars : int
         Truncate post content to this many characters before embedding.
         Reduces peak memory by limiting token sequence length.
@@ -77,6 +83,7 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         revision: str | None = None,
         prefix: str = "",
         batch_size: int = 8,
+        token_budget: int = TOKEN_BUDGET,
         max_content_chars: int = 2000,
     ) -> None:
         if model_name is None:
@@ -115,6 +122,7 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         self.revision = revision
         self.prefix = prefix
         self.batch_size = batch_size
+        self.token_budget = token_budget
         self.max_content_chars = max_content_chars
 
     def process(self, posts: list, allow_overwrite: bool = True) -> None:  # type: ignore
@@ -175,15 +183,10 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
                 pooling=self.pooling,
                 revision=self.revision,
                 prefix=self.prefix,
+                batch_size=self.batch_size,
+                token_budget=self.token_budget,
             )
-            uncached_texts = [contents[i] for i in uncached_indices]
-
-            # Process in batches
-            new_embeddings: list[np.ndarray] = []
-            for start in range(0, len(uncached_texts), self.batch_size):
-                batch = uncached_texts[start : start + self.batch_size]
-                batch_embs = embedder.embed(batch)
-                new_embeddings.extend(batch_embs)
+            new_embeddings = embedder.embed_all([contents[i] for i in uncached_indices])
 
             # Fill in and cache
             cache_entries: list[tuple[str, str, np.ndarray]] = []

--- a/prelims_cli/embedding/recommender.py
+++ b/prelims_cli/embedding/recommender.py
@@ -67,7 +67,11 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         the length of the posts in the batch, not their number.
     max_content_chars : int
         Truncate post content to this many characters before embedding.
-        Reduces peak memory by limiting token sequence length.
+        The default of 8000 is a quality choice: on a 419-post corpus, 2000
+        characters discarded 44% of the Japanese text and 64% of the English,
+        and raising it improved tag agreement at every topk in both languages.
+        Beyond 8000 the measurements flattened out. Peak memory is bounded by
+        ``token_budget``, not by this.
     """
 
     def __init__(
@@ -84,7 +88,7 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         prefix: str = "",
         batch_size: int = 8,
         token_budget: int = TOKEN_BUDGET,
-        max_content_chars: int = 2000,
+        max_content_chars: int = 8000,
     ) -> None:
         if model_name is None:
             if language not in LANGUAGE_MODELS:

--- a/prelims_cli/processor.py
+++ b/prelims_cli/processor.py
@@ -74,6 +74,15 @@ def set_embedding_recommender(h: StaticSitePostsHandler, cfg: DictConfig) -> Non
             "prefix": cfg.get("prefix", ""),
             "batch_size": cfg.get("batch_size", 32),
         }
+        # Only forwarded when set, so the library keeps ownership of the
+        # defaults — these two decide peak memory together and are easy to
+        # put out of step from a site config.
+        token_budget = cfg.get("token_budget", None)
+        if token_budget is not None:
+            kwargs["token_budget"] = token_budget
+        max_content_chars = cfg.get("max_content_chars", None)
+        if max_content_chars is not None:
+            kwargs["max_content_chars"] = max_content_chars
         cache_db = cfg.get("cache_db", None)
         if cache_db is not None:
             kwargs["cache_db"] = cache_db

--- a/tests/test_embedding_recommender.py
+++ b/tests/test_embedding_recommender.py
@@ -31,7 +31,7 @@ def _fake_embeddings(texts: list[str]) -> np.ndarray:
 def test_process_basic(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     """Basic process: 3 posts, verify recommendations are set."""
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/a.md", "Python machine learning"),
@@ -56,7 +56,7 @@ def test_process_basic(MockEmbedder: MagicMock, tmp_path: Path) -> None:
 @patch("prelims_cli.embedding.recommender.OnnxEmbedder")
 def test_permalink_generation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/MyPost.md", "content alpha"),
@@ -83,7 +83,7 @@ def test_permalink_generation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
 @patch("prelims_cli.embedding.recommender.OnnxEmbedder")
 def test_permalink_index_file(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/my-article/index.md", "content one"),
@@ -106,7 +106,7 @@ def test_permalink_index_file(MockEmbedder: MagicMock, tmp_path: Path) -> None:
 def test_caching_behavior(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     """Second run should use cache and not call embedder."""
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/a.md", "same content"),
@@ -126,7 +126,7 @@ def test_caching_behavior(MockEmbedder: MagicMock, tmp_path: Path) -> None:
 
     # Reset mock
     MockEmbedder.reset_mock()
-    embedder_instance.embed.reset_mock()
+    embedder_instance.embed_all.reset_mock()
 
     # Second run with same content: should NOT instantiate embedder
     posts2 = [
@@ -153,7 +153,7 @@ def test_partial_cache_hit(MockEmbedder: MagicMock, tmp_path: Path) -> None:
         return _fake_embeddings(texts)
 
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = tracking_embed
+    embedder_instance.embed_all.side_effect = tracking_embed
 
     cache_path = str(tmp_path / "cache.db")
 
@@ -208,7 +208,7 @@ def test_content_truncation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
         return _fake_embeddings(texts)
 
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = capture_embed
+    embedder_instance.embed_all.side_effect = capture_embed
 
     long_content = "A" * 5000
     posts = [
@@ -235,7 +235,7 @@ def test_content_truncation(MockEmbedder: MagicMock, tmp_path: Path) -> None:
 def test_content_truncation_cache_key(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     """Cache key should reflect truncated content, not original."""
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     cache_path = str(tmp_path / "cache.db")
 
@@ -252,7 +252,7 @@ def test_content_truncation_cache_key(MockEmbedder: MagicMock, tmp_path: Path) -
     )
     rec.process(posts)
     MockEmbedder.reset_mock()
-    embedder_instance.embed.reset_mock()
+    embedder_instance.embed_all.reset_mock()
 
     # Same original content, same truncation → cache hit
     posts2 = [
@@ -272,7 +272,7 @@ def test_content_truncation_cache_key(MockEmbedder: MagicMock, tmp_path: Path) -
 @patch("prelims_cli.embedding.recommender.OnnxEmbedder")
 def test_lower_path_false(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/MyPost.md", "content alpha"),
@@ -357,7 +357,7 @@ def test_pooling_overrides_language_default() -> None:
 @patch("prelims_cli.embedding.recommender.OnnxEmbedder")
 def test_pooling_passed_to_embedder(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/a.md", "content A"),
@@ -395,7 +395,7 @@ def test_explicit_model_leaves_revision_unpinned() -> None:
 @patch("prelims_cli.embedding.recommender.OnnxEmbedder")
 def test_revision_passed_to_embedder(MockEmbedder: MagicMock, tmp_path: Path) -> None:
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     posts = [
         _make_post("/posts/a.md", "content A"),
@@ -416,7 +416,7 @@ def test_revision_change_invalidates_cache(
 ) -> None:
     """Vectors from one revision must not be reused after repinning."""
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     cache_path = str(tmp_path / "cache.db")
 
@@ -447,7 +447,7 @@ def test_cache_version_bump_invalidates_cache(
     reflects.
     """
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     cache_path = str(tmp_path / "cache.db")
 
@@ -483,7 +483,7 @@ def test_pooling_change_invalidates_cache(
 ) -> None:
     """Vectors pooled one way must not be reused after switching pooling."""
     embedder_instance = MockEmbedder.return_value
-    embedder_instance.embed.side_effect = _fake_embeddings
+    embedder_instance.embed_all.side_effect = _fake_embeddings
 
     cache_path = str(tmp_path / "cache.db")
 

--- a/tests/test_onnx_embedder.py
+++ b/tests/test_onnx_embedder.py
@@ -218,6 +218,39 @@ def test_embed_all_returns_input_order() -> None:
     np.testing.assert_array_almost_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch_size": 0}, "batch_size must be at least 1"),
+        ({"token_budget": 0}, "token_budget must be at least 1"),
+        ({"token_budget": -1}, "token_budget must be at least 1"),
+    ],
+)
+def test_non_positive_batching_limits_raise(kwargs: dict, message: str) -> None:
+    """Zero degrades to one text per batch instead of failing, so reject it."""
+    with pytest.raises(ValueError, match=message):
+        OnnxEmbedder(pooling="mean", **kwargs)
+
+
+def test_embed_all_rejects_a_batch_of_the_wrong_size() -> None:
+    """A short result would otherwise leave Nones and fail inside np.stack."""
+
+    class _ShortSession:
+        def run(self, output_names: Any, inputs: dict[str, np.ndarray]) -> list:
+            return [np.ones((1, 2, 2), dtype=np.float32)]
+
+    embedder = OnnxEmbedder.__new__(OnnxEmbedder)
+    embedder.session = _ShortSession()  # type: ignore[assignment]
+    embedder.tokenizer = _LengthTokenizer()  # type: ignore[assignment]
+    embedder.pooling = "cls"
+    embedder.prefix = ""
+    embedder.batch_size = 8
+    embedder.token_budget = 4096
+
+    with pytest.raises(ValueError, match="argument 2 is shorter"):
+        embedder.embed_all(["aa", "bb"])
+
+
 def test_embed_all_handles_empty_input() -> None:
     embedder = OnnxEmbedder.__new__(OnnxEmbedder)
     assert embedder.embed_all([]).shape == (0, 0)

--- a/tests/test_onnx_embedder.py
+++ b/tests/test_onnx_embedder.py
@@ -9,6 +9,7 @@ from prelims_cli.embedding.inference import (
     _cls_pool,
     _l2_normalize,
     _mean_pool,
+    _plan_batches,
 )
 
 
@@ -135,6 +136,91 @@ def test_invalid_pooling_raises() -> None:
 def test_language_models_declare_pooling() -> None:
     assert LANGUAGE_MODELS["ja"]["pooling"] == "mean"
     assert LANGUAGE_MODELS["en"]["pooling"] == "cls"
+
+
+def test_plan_batches_covers_every_index_once() -> None:
+    lengths = [10, 3, 7, 1, 5, 20, 2]
+    batches = _plan_batches(lengths, token_budget=20, max_batch=4)
+    assert sorted(i for b in batches for i in b) == list(range(len(lengths)))
+
+
+def test_plan_batches_respects_token_budget() -> None:
+    lengths = [4, 4, 4, 4, 4, 4]
+    batches = _plan_batches(lengths, token_budget=8, max_batch=100)
+    for batch in batches:
+        assert len(batch) * max(lengths[i] for i in batch) <= 8
+    assert len(batches) == 3
+
+
+def test_plan_batches_respects_max_batch() -> None:
+    lengths = [1] * 10
+    batches = _plan_batches(lengths, token_budget=1000, max_batch=3)
+    assert [len(b) for b in batches] == [3, 3, 3, 1]
+
+
+def test_plan_batches_keeps_oversized_text_alone() -> None:
+    """A text over budget on its own must still be embedded, not dropped."""
+    lengths = [2, 2, 500]
+    batches = _plan_batches(lengths, token_budget=8, max_batch=100)
+    assert [2] in batches
+    assert sorted(i for b in batches for i in b) == [0, 1, 2]
+
+
+def test_plan_batches_groups_similar_lengths() -> None:
+    """The point of sorting: padding stays close to the real token count.
+
+    Interleaved short and long texts would otherwise pad every batch up to
+    the long one — the failure mode this batching exists to avoid.
+    """
+    lengths = [1, 100, 1, 100, 1, 100]
+    batches = _plan_batches(lengths, token_budget=200, max_batch=3)
+    padded = sum(len(b) * max(lengths[i] for i in b) for b in batches)
+    assert padded <= sum(lengths) * 1.1
+
+
+class _LengthTokenizer:
+    """Tokenizes each text into ``len(text)`` copies of its own length.
+
+    Lets a test tell embeddings apart by the length of the text they came
+    from, which is what checking the restored order needs.
+    """
+
+    def encode_batch(self, texts: list[str]) -> list[_FakeEncoding]:
+        return [_FakeEncoding([len(t)] * len(t)) for t in texts]
+
+
+class _IdentitySession:
+    """Returns hidden states carrying each row's first token id."""
+
+    def run(self, output_names: Any, inputs: dict[str, np.ndarray]) -> list[np.ndarray]:
+        ids = inputs["input_ids"]
+        first = ids[:, :1].astype(np.float32)
+        hidden = np.repeat(first[:, :, np.newaxis], ids.shape[1], axis=1)
+        return [np.concatenate([hidden, np.ones_like(hidden)], axis=2)]
+
+
+def test_embed_all_returns_input_order() -> None:
+    """Batching sorts by length, so the result has to be put back."""
+    embedder = OnnxEmbedder.__new__(OnnxEmbedder)
+    embedder.session = _IdentitySession()  # type: ignore[assignment]
+    embedder.tokenizer = _LengthTokenizer()  # type: ignore[assignment]
+    embedder.pooling = "cls"
+    embedder.prefix = ""
+    embedder.batch_size = 8
+    embedder.token_budget = 8
+
+    texts = ["a" * n for n in (5, 1, 3, 2, 4)]
+    result = embedder.embed_all(texts)
+
+    expected = _l2_normalize(
+        np.array([[float(len(t)), 1.0] for t in texts], dtype=np.float32)
+    )
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_embed_all_handles_empty_input() -> None:
+    embedder = OnnxEmbedder.__new__(OnnxEmbedder)
+    assert embedder.embed_all([]).shape == (0, 0)
 
 
 def test_l2_normalize() -> None:


### PR DESCRIPTION
#13 was merged into this branch, so this PR now carries both changes. **The "embeddings are unchanged" note from the original description no longer holds** — see the upgrade impact section.

## 1. Token-budget batching

Batches are padded to their longest member and attention memory grows with the square of that length, so a fixed number of posts per batch leaves peak memory dependent on which posts happen to land together.

Article lengths are heavily skewed. On the 419-post Japanese corpus truncated at 8000 characters the median is 545 tokens and the longest is 3636, and long posts are spread through the corpus — so in file order nearly every batch of 8 caught one and was padded up to it. Measured on that corpus:

| | processed tokens | attention work |
|---|---|---|
| fixed batch of 8, file order | 0.83M | 2.38G |
| length-sorted, fixed batch of 8 | 0.41M | 2.38G |
| **token budget 4096** | **0.40M** | **0.78G** |

for 0.40M real tokens.

`OnnxEmbedder.embed_all()` sorts by token length and packs each batch until it would exceed a budget of padded token slots. Sorting alone would not have been enough — it removes the waste but leaves the longest posts batched together, at the same peak. That is the second row above, and it is why the fix is a budget rather than a sort.

`batch_size` stays as a cap on posts per batch, so existing configs keep working, but it can no longer bound memory on its own and the docstring says so. Both it and `token_budget` are rejected at zero or below, where they would otherwise degrade silently to one post per batch.

## 2. `max_content_chars` 2000 → 8000

The 2000-character cap was chosen to keep peak memory down, not for quality, and it was discarding most of each post: 44% of the Japanese text and 64% of the English on a corpus whose English median is 3467 characters. Most posts were being compared on their opening section alone.

Tag agreement with hand-written `tags`/`categories`, in points:

| corpus | k=3 | k=5 | k=10 |
|---|---|---|---|
| ja 419 posts | +3.8 | +1.2 | +0.3 |
| en 33 posts | +3.4 | +4.1 | +1.7 |

The only change in the evaluation whose sign held across all six points. Going further, to 20000 characters (past the longest post in either corpus), flattened out — Japanese moved slightly negative and English changed sign between topk values, all within a point.

Part 1 is what makes this affordable: the same corpus at 8000 characters took 12.8 GB with fixed batches (it crashed) and 4.9 GB with the budget. The remaining cost is compute — 1.7x the tokens and 4.4x the attention work of 2000.

## Upgrade impact

`max_content_chars` is part of the cache key, so **the first run after upgrading re-embeds the whole corpus.** Sites that would rather not pay that can pin `max_content_chars: 2000` in their config; both it and `token_budget` are forwarded from site config as of this PR.

The batching change on its own does not affect embeddings — padded positions are already excluded by the attention mask and by mean pooling, so only the grouping differs.

## Verification

73 unit tests pass, including the batch planner (every index covered exactly once, budget and count caps respected, an oversized text kept in a batch of its own, padding staying close to the real token count on interleaved lengths, input order restored after the sort, a wrong-sized batch raising where it happens) and the constructor's rejection of non-positive limits.

Integration tests were not run — this environment cannot reach huggingface.co.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd