### PR TITLE
Embed 8000 characters of a post by default, not 2000

### DIFF
--- a/prelims_cli/embedding/recommender.py
+++ b/prelims_cli/embedding/recommender.py
@@ -67,7 +67,11 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         the length of the posts in the batch, not their number.
     max_content_chars : int
         Truncate post content to this many characters before embedding.
-        Reduces peak memory by limiting token sequence length.
+        The default of 8000 is a quality choice: on a 419-post corpus, 2000
+        characters discarded 44% of the Japanese text and 64% of the English,
+        and raising it improved tag agreement at every topk in both languages.
+        Beyond 8000 the measurements flattened out. Peak memory is bounded by
+        ``token_budget``, not by this.
     """
 
     def __init__(
@@ -84,7 +88,7 @@ class EmbeddingRecommender(BaseFrontMatterProcessor):
         prefix: str = "",
         batch_size: int = 8,
         token_budget: int = TOKEN_BUDGET,
-        max_content_chars: int = 2000,
+        max_content_chars: int = 8000,
     ) -> None:
         if model_name is None:
             if language not in LANGUAGE_MODELS:


### PR DESCRIPTION
Stacked on #12 — merge that first. This branch contains #12's commit, so the diff here shows only the default change once #12 lands.

The 2000-character cap was chosen to keep peak memory down, not for quality, and it was discarding most of each post: 44% of the Japanese text and 64% of the English on a 419-post corpus whose English median is 3467 characters. Most posts were being compared on their opening section alone.

## What the measurement showed

Tag agreement with hand-written `tags`/`categories`, in points:

| corpus | k=3 | k=5 | k=10 |
|---|---|---|---|
| ja 419 posts | +3.8 | +1.2 | +0.3 |
| en 33 posts | +3.4 | +4.1 | +1.7 |

This is the only change in the evaluation whose sign held across all six points. Going further, to 20000 characters (past the longest post in either corpus), flattened out — Japanese moved slightly negative and English changed sign between topk values, all within a point. 8000 is where the gain stops.

## Why now

Memory was the reason to keep this low, and #12 removes it: token-budget batching bounds peak memory independently of post length. Running the 419-post corpus at 8000 characters took 12.8 GB with fixed batches (it crashed) and 4.9 GB with the budget.

The remaining cost is compute — 8000 characters is 1.7x the tokens and 4.4x the attention work of 2000 on that corpus.

## Upgrade impact

`max_content_chars` is part of the cache key, so **the first run after upgrading re-embeds the whole corpus.** Sites that would rather not pay that can pin `max_content_chars: 2000` in their config; the setting is forwarded from site config as of #12.

## Verification

69 unit tests pass. The truncation tests pass an explicit value and are unaffected by the default.

Integration tests were not run — this environment cannot reach huggingface.co.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd)_