### PR TITLE
Compare the text prelims embeds, not the raw markdown

### DIFF
--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -55,7 +55,7 @@ from collections.abc import Sequence
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
-import yaml
+from prelims.post import Post as PrelimsPost  # type: ignore
 
 from prelims_cli.embedding.recommender import EmbeddingRecommender
 
@@ -75,20 +75,20 @@ class Post:
 
 
 def split_front_matter(path: Path) -> tuple[dict, str]:
-    """Return (front matter dict, body). Best-effort on odd files."""
-    text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        return {}, text
-    _, _, rest = text.partition("\n")
-    end = rest.find("\n---")
-    if end == -1:
-        return {}, text
-    head, body = rest[:end], rest[end + len("\n---") :].lstrip()
-    try:
-        meta = yaml.safe_load(head)
-    except yaml.YAMLError:
-        return {}, body
-    return (meta if isinstance(meta, dict) else {}), body
+    """Return (front matter dict, embedded text) for one article.
+
+    The text is what prelims itself would hand the recommender, not the raw
+    markdown: prelims strips HTML tags, code fences, math and URLs before
+    embedding. Reading the file directly overstates how much the model sees —
+    on a corpus of Medium exports it counted 154 articles over 2000 characters
+    where the real pipeline had 93 — which makes any comparison of input
+    length measure something other than what runs in production.
+
+    Parsed by prelims' own loader so the two cannot drift apart.
+    """
+    post = PrelimsPost.load(str(path))
+    meta = post.front_matter if isinstance(post.front_matter, dict) else {}
+    return meta, post.content
 
 
 def tags_of(meta: dict, keys: Sequence[str] = TAG_KEYS) -> set[str]:

--- a/scripts/compare_embedding_variants.py
+++ b/scripts/compare_embedding_variants.py
@@ -86,7 +86,7 @@ def split_front_matter(path: Path) -> tuple[dict, str]:
 
     Parsed by prelims' own loader so the two cannot drift apart.
     """
-    post = PrelimsPost.load(str(path))
+    post = PrelimsPost.load(path)
     meta = post.front_matter if isinstance(post.front_matter, dict) else {}
     return meta, post.content
 


### PR DESCRIPTION
`compare_embedding_variants.py` read article bodies itself, stripping only the front matter. prelims strips more before embedding — HTML tags, code fences, math blocks and URLs — so every measurement ran on text the recommender never sees.

## How this surfaced

A production run after upgrading reported `Cache hit: 325/418` and `18/33`, meaning 93 Japanese and 15 English articles changed when `max_content_chars` went from 2000 to 8000. The script's own accounting had predicted 154 and 29. Re-counting with prelims' filters reproduces 93 and 15 exactly.

| | script (raw file) | prelims (embedded text) |
|---|---|---|
| ja median | 1,205 | **773** |
| ja max | 18,838 | **8,890** |
| ja over 2000 | 154 | **93** |
| en median | 3,467 | **1,854** |
| en over 2000 | 29 | **15** |

The corpus is largely Medium exports, which carry a lot of inline HTML and bare URLs — hence the size of the gap.

## What it invalidates

A model-vs-model comparison survives: both variants read the same text, so the ranking between them holds.

An experiment on **input length** does not. It was measuring a corpus that does not exist, and the effect is in the direction that matters — the raw text crosses the 2000-character cap far more often than the real thing, so the measured benefit of raising the cap was drawn from more articles than production would see.

## Fix

Parse with `prelims.post.Post.load()` rather than a local reimplementation, so the two cannot drift apart again. This also means the script picks up any future change to prelims' filters for free.

One side effect worth knowing: the Japanese curated-tag count moves from 94 to 93, because front matter now goes through prelims' parser as well. Metrics computed against curated tags shift slightly as a result.

## Verification

The script's length accounting now matches the production run exactly (ja 93, en 15 articles over 2000 characters). 73 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd)_