### PR TITLE
Keep the evaluation material out of the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,16 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+# Without this, hatchling puts everything the repo tracks into the sdist. The
+# evaluation material — scripts/ and judgments/, the latter carrying two 150 KB
+# reports — belongs in the repo, not in a package anyone installs. Keep the
+# sdist to what it takes to build and test: the package and its tests.
+[tool.hatch.build.targets.sdist]
+include = ["prelims_cli", "tests", "README.md", "LICENSE"]
+# hatchling adds every README it finds back on top of `include`, so the two
+# directories have to be named again here.
+exclude = ["scripts", "judgments"]
+
 [dependency-groups]
 dev = [
   "pytest>=6.0",


### PR DESCRIPTION
hatchling defaults to shipping everything the repo tracks, so the sdist has been
picking up directories that have nothing to do with installing the package.

`scripts/` has been in there since v0.0.10, when it was added. v0.0.11 added
`judgments/` on top — two 150 KB HTML reports plus the label corpus — which took
the sdist from 23 KB to 194 KB.

**The wheel was never affected.** It only ever carried `prelims_cli/`, so nobody
who ran `pip install prelims-cli` got any of this. This is an sdist-only fix, and
since v0.0.11 is already published it lands for the release after it.

## Change

```toml
[tool.hatch.build.targets.sdist]
include = ["prelims_cli", "tests", "README.md", "LICENSE"]
exclude = ["scripts", "judgments"]
```

`exclude` is needed alongside `include` because hatchling adds every README it
finds back on top of the include list — with `include` alone,
`scripts/README.md` and `judgments/README.md` both survived.

## Result

| | before | after |
| --- | --- | --- |
| sdist | 194 KB | 23 KB |
| wheel | 19 KB | 19 KB (unchanged) |

The sdist now holds `prelims_cli/`, `tests/`, `README.md`, `LICENSE` and
`pyproject.toml` — enough to build and to run the suite, and nothing else.

## Verification

- Built the sdist, extracted it, and ran the test suite from the extraction:
  **75 passed** (the 3 deselected are the integration tests that download a real
  model)
- Confirmed the wheel's file list is unchanged
- `ruff check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk3QGx2m6AzinN46JLiAnd)_